### PR TITLE
Fix item recipe mapping and track updates

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -48,9 +48,13 @@ export async function initDatabase() {
         level INT,
         statsId TEXT,
         itemRecipeId JSON,
-        recipeId JSON
+        recipeId JSON,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
+    await conn.query(
+      "ALTER TABLE `DatabaseItems` ADD COLUMN IF NOT EXISTS `lastModified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    );
 
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabaseItemRecipes (
@@ -67,9 +71,13 @@ export async function initDatabase() {
         level INT,
         statsId TEXT,
         learnableRecipeIds TEXT,
-        rewardId JSON
+        rewardId JSON,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
+    await conn.query(
+      "ALTER TABLE `DatabaseItemRecipes` ADD COLUMN IF NOT EXISTS `lastModified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    );
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabaseStats (
         id VARCHAR(255) PRIMARY KEY,
@@ -133,9 +141,13 @@ export async function initDatabase() {
         generalResourceCost JSON,
         qualityFormula TEXT,
         craftingCurrencyCostId TEXT,
-        rewardItem JSON
+        rewardItem JSON,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
+    await conn.query(
+      "ALTER TABLE `DatabaseRecipes` ADD COLUMN IF NOT EXISTS `lastModified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    );
 
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabaseEquipment (
@@ -153,9 +165,13 @@ export async function initDatabase() {
         statsId TEXT,
         level INT,
         grade TEXT,
-        itemRecipeId JSON
+        itemRecipeId JSON,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
+    await conn.query(
+      "ALTER TABLE `DatabaseEquipment` ADD COLUMN IF NOT EXISTS `lastModified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    );
 
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabaseGear (
@@ -177,9 +193,13 @@ export async function initDatabase() {
         grade TEXT,
         enchantmentId TEXT,
         deconstructionRecipeId TEXT,
-        itemRecipeId JSON
+        itemRecipeId JSON,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
+    await conn.query(
+      "ALTER TABLE `DatabaseGear` ADD COLUMN IF NOT EXISTS `lastModified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    );
 
     console.log("Database tables initialized");
   } finally {

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -4,6 +4,15 @@
 
 import { pool } from "./config.js";
 
+async function ensureLastModifiedColumn(client, table) {
+  const query = `ALTER TABLE \`${table}\` ADD COLUMN IF NOT EXISTS \`lastModified\` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`;
+  try {
+    await client.query(query);
+  } catch (err) {
+    // Ignore if permissions prevent alteration
+  }
+}
+
 /**
  * Function to save an item recipe to the MySQL database
  * @param {Object} item - Item object to save
@@ -12,30 +21,42 @@ import { pool } from "./config.js";
 async function saveItemRecipeToDatabase(item) {
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseItemRecipes');
     const query = `
-      INSERT INTO "DatabaseItemRecipes" (
-        id, name, description, type, tag, icon, "rarityMin", "rarityMax", level, "statsId",
-        "learnableRecipeIds", "rewardId", layout, "typeDescription"
+      INSERT INTO \`DatabaseItemRecipes\` (
+        id, name, description, type, tag, icon, \`rarityMin\`, \`rarityMax\`, level, \`statsId\`,
+        \`learnableRecipeIds\`, \`rewardId\`, layout, \`typeDescription\`
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
-        name = ?, description = ?, type = ?, tag = ?, icon = ?, 
-        "rarityMin" = ?, "rarityMax" = ?, level = ?, "statsId" = ?,
-        "learnableRecipeIds" = ?, "rewardId" = ?, layout = ?, "typeDescription" = ?
+        name = VALUES(name),
+        description = VALUES(description),
+        type = VALUES(type),
+        tag = VALUES(tag),
+        icon = VALUES(icon),
+        \`rarityMin\` = VALUES(\`rarityMin\`),
+        \`rarityMax\` = VALUES(\`rarityMax\`),
+        level = VALUES(level),
+        \`statsId\` = VALUES(\`statsId\`),
+        \`learnableRecipeIds\` = VALUES(\`learnableRecipeIds\`),
+        \`rewardId\` = VALUES(\`rewardId\`),
+        layout = VALUES(layout),
+        \`typeDescription\` = VALUES(\`typeDescription\`),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     const values = [
       item.id,
       item.name,
       JSON.stringify(item.description || []),
-      item.type,
+      item.type ?? null,
       JSON.stringify(item.tag || []),
-      item.icon,
-      item.rarityMin,
-      item.rarityMax,
-      item.level,
-      item.statsId,
-      item.learnableRecipeIds,
+      item.icon ?? null,
+      item.rarityMin ?? null,
+      item.rarityMax ?? null,
+      item.level ?? null,
+      item.statsId ?? null,
+      item.learnableRecipeIds ?? null,
       JSON.stringify(item.rewardId || []),
       item.layout || "itemRecipe",
       item.typeDescription || "",
@@ -60,24 +81,24 @@ async function saveStatToDatabase(statData) {
   try {
     // Insert into DatabaseStats table
     const query = `
-      INSERT INTO "DatabaseStats" (
+      INSERT INTO \`DatabaseStats\` (
         id, common, uncommon, rare, heroic, epic, legendary, artifact, durability
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
-        common = ?,
-        uncommon = ?,
-        rare = ?,
-        heroic = ?,
-        epic = ?,
-        legendary = ?,
-        artifact = ?,
-        durability = ?
+        common = VALUES(common),
+        uncommon = VALUES(uncommon),
+        rare = VALUES(rare),
+        heroic = VALUES(heroic),
+        epic = VALUES(epic),
+        legendary = VALUES(legendary),
+        artifact = VALUES(artifact),
+        durability = VALUES(durability)
     `;
 
     // Convert each rarity object to JSON string
     const values = [
-      statData.id,
+      statData.id ?? null,
       JSON.stringify(statData.common || {}),
       JSON.stringify(statData.uncommon || {}),
       JSON.stringify(statData.rare || {}),
@@ -105,21 +126,23 @@ async function saveStatToDatabase(statData) {
 async function saveSetBonusToDatabase(setBonusData) {
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseSetBonuses');
     // Insert into DatabaseSetBonuses table
     const query = `
-      INSERT INTO "DatabaseSetBonuses" (
-        id, name, "setEffects"
+      INSERT INTO \`DatabaseSetBonuses\` (
+        id, name, \`setEffects\`
       ) VALUES (
         ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
-        name = ?,
-        "setEffects" = ?
+        name = VALUES(name),
+        \`setEffects\` = VALUES(\`setEffects\`),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     // Convert setEffects array to JSON string
     const values = [
-      setBonusData.id,
-      setBonusData.name,
+      setBonusData.id ?? null,
+      setBonusData.name ?? null,
       JSON.stringify(setBonusData.setEffects || []),
     ];
 
@@ -140,20 +163,22 @@ async function saveSetBonusToDatabase(setBonusData) {
 async function saveEnchantmentDefToDatabase(enchantmentDefData) {
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseEnchantmentDef');
     // Insert into DatabaseEnchantmentDef table
     const query = `
-      INSERT INTO "DatabaseEnchantmentDef" (
+      INSERT INTO \`DatabaseEnchantmentDef\` (
         id, name, levels
       ) VALUES (
         ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
-        name = ?,
-        levels = ?
+        name = VALUES(name),
+        levels = VALUES(levels),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     const values = [
-      enchantmentDefData.id,
-      enchantmentDefData.name,
+      enchantmentDefData.id ?? null,
+      enchantmentDefData.name ?? null,
       enchantmentDefData.levels || [],
     ];
 
@@ -176,35 +201,37 @@ async function saveEnchantmentDefToDatabase(enchantmentDefData) {
 async function saveEnchantmentLevelToDatabase(enchantmentLevelData) {
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseEnchantmentLevel');
     // Insert into DatabaseEnchantmentLevel table
     const query = `
-      INSERT INTO "DatabaseEnchantmentLevel" (
-        id, name, "primary", core, cost, success, failure, loss, "all", "break"
+      INSERT INTO \`DatabaseEnchantmentLevel\` (
+        id, name, \`primary\`, core, cost, success, failure, loss, \`all\`, \`break\`
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
-        name = ?,
-        "primary" = ?,
-        core = ?,
-        cost = ?,
-        success = ?,
-        failure = ?,
-        loss = ?,
-        "all" = ?,
-        "break" = ?
+        name = VALUES(name),
+        \`primary\` = VALUES(\`primary\`),
+        core = VALUES(core),
+        cost = VALUES(cost),
+        success = VALUES(success),
+        failure = VALUES(failure),
+        loss = VALUES(loss),
+        \`all\` = VALUES(\`all\`),
+        \`break\` = VALUES(\`break\`),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     const values = [
-      enchantmentLevelData.id,
-      enchantmentLevelData.name,
-      enchantmentLevelData.primary,
-      enchantmentLevelData.core,
-      enchantmentLevelData.cost,
-      enchantmentLevelData.success,
-      enchantmentLevelData.failure,
-      enchantmentLevelData.loss,
-      enchantmentLevelData.all,
-      enchantmentLevelData.break,
+      enchantmentLevelData.id ?? null,
+      enchantmentLevelData.name ?? null,
+      enchantmentLevelData.primary ?? null,
+      enchantmentLevelData.core ?? null,
+      enchantmentLevelData.cost ?? null,
+      enchantmentLevelData.success ?? null,
+      enchantmentLevelData.failure ?? null,
+      enchantmentLevelData.loss ?? null,
+      enchantmentLevelData.all ?? null,
+      enchantmentLevelData.break ?? null,
     ];
 
     await client.execute(query, values);
@@ -219,44 +246,58 @@ async function saveEnchantmentLevelToDatabase(enchantmentLevelData) {
 }
 
 /**
- * Function to save an recipe to the MySQL database
+ * Function to save a recipe to the MySQL database
  * @param {Object} item - Item object to save
  * @returns {Promise} - Promise that resolves when the item is saved
  */
 async function saveRecipeToDatabase(item) {
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseRecipes');
     // Values are stored as JSON strings for MySQL
     const query = `
-      INSERT INTO "DatabaseRecipes" (
-        id, name, profession, certification, learnable, "overrideName", overrides, tags,
-        fuel, "baseDuration", "rewardId", "primaryResourceCosts", "generalResourceCost",
-        "qualityFormula", "craftingCurrencyCostId", "rewardItem", layout
+      INSERT INTO \`DatabaseRecipes\` (
+        id, name, profession, certification, learnable, \`overrideName\`, overrides, tags,
+        fuel, \`baseDuration\`, \`rewardId\`, \`primaryResourceCosts\`, \`generalResourceCost\`,
+        \`qualityFormula\`, \`craftingCurrencyCostId\`, \`rewardItem\`, layout
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
-        name = ?, profession = ?, certification = ?, learnable = ?, "overrideName" = ?,
-        overrides = ?, tags = ?, fuel= ?, "baseDuration" = ?, "rewardId" = ?, "primaryResourceCosts" = ?,
-        "generalResourceCost" = ?, "qualityFormula" = ?, "craftingCurrencyCostId" = ?, "rewardItem" = ?,
-        layout = ?
+        name = VALUES(name),
+        profession = VALUES(profession),
+        certification = VALUES(certification),
+        learnable = VALUES(learnable),
+        \`overrideName\` = VALUES(\`overrideName\`),
+        overrides = VALUES(overrides),
+        tags = VALUES(tags),
+        fuel = VALUES(fuel),
+        \`baseDuration\` = VALUES(\`baseDuration\`),
+        \`rewardId\` = VALUES(\`rewardId\`),
+        \`primaryResourceCosts\` = VALUES(\`primaryResourceCosts\`),
+        \`generalResourceCost\` = VALUES(\`generalResourceCost\`),
+        \`qualityFormula\` = VALUES(\`qualityFormula\`),
+        \`craftingCurrencyCostId\` = VALUES(\`craftingCurrencyCostId\`),
+        \`rewardItem\` = VALUES(\`rewardItem\`),
+        layout = VALUES(layout),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     const values = [
-      item.id,
-      item.name,
-      item.profession,
-      item.certification,
-      item.learnable,
-      item.overrideName,
+      item.id ?? null,
+      item.name ?? null,
+      item.profession ?? null,
+      item.certification ?? null,
+      item.learnable ?? null,
+      item.overrideName ?? null,
       JSON.stringify(item.overrides || []),
       JSON.stringify(item.tags || []),
-      item.fuel,
-      item.baseDuration,
-      item.rewardId,
+      item.fuel ?? null,
+      item.baseDuration ?? null,
+      item.rewardId ?? null,
       JSON.stringify(item.primaryResourceCosts || []),
       JSON.stringify(item.generalResourceCost || []),
-      item.qualityFormula,
-      item.craftingCurrencyCostId,
+      item.qualityFormula ?? null,
+      item.craftingCurrencyCostId ?? null,
       JSON.stringify(item.rewardItem || []),
       item.layout || "recipe",
     ];
@@ -283,9 +324,10 @@ async function batchFindItemRecipes(itemIds) {
   const client = await pool.getConnection();
   try {
     const query = `
-      SELECT r.id, jt.item_id
-      FROM \`DatabaseItemRecipes\` r
-      JOIN JSON_TABLE(r.rewardId, '$[*]' COLUMNS(item_id VARCHAR(255) PATH '$')) as jt
+      SELECT ir.id AS recipe_item_id, jt.item_id
+      FROM \`DatabaseRecipes\` dr
+      JOIN JSON_TABLE(dr.rewardItem, '$[*]' COLUMNS(item_id VARCHAR(255) PATH '$')) AS jt ON TRUE
+      JOIN \`DatabaseItemRecipes\` ir ON ir.learnableRecipeIds = dr.id
       WHERE jt.item_id IN (?)
     `;
 
@@ -302,7 +344,7 @@ async function batchFindItemRecipes(itemIds) {
     // Populate the map with the results
     rows.forEach((row) => {
       if (row.item_id && recipeMap[row.item_id]) {
-        recipeMap[row.item_id].push(row.id);
+        recipeMap[row.item_id].push(row.recipe_item_id);
       }
     });
 
@@ -326,30 +368,32 @@ async function batchSaveEquipmentToDatabase(items) {
 
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseEquipment');
     // Begin transaction
-    await client.execute("BEGIN");
+    await client.query("BEGIN");
 
     // Prepare the query
     const query = `
-      INSERT INTO "DatabaseEquipment" (
-        id, name, "typeDescription", description, type, subtype, tag, icon, "rarityMin", "rarityMax", 
-        "statsId", level, grade, "itemRecipeId", layout
+      INSERT INTO \`DatabaseEquipment\` (
+        id, name, \`typeDescription\`, description, type, subtype, tag, icon, \`rarityMin\`, \`rarityMax\`,
+        \`statsId\`, level, grade, \`itemRecipeId\`, layout
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON DUPLICATE KEY UPDATE
         name = VALUES(name),
-        "typeDescription" = VALUES("typeDescription"),
+        \`typeDescription\` = VALUES(\`typeDescription\`),
         description = VALUES(description),
         type = VALUES(type),
         subtype = VALUES(subtype),
         tag = VALUES(tag),
         icon = VALUES(icon),
-        "rarityMin" = VALUES("rarityMin"),
-        "rarityMax" = VALUES("rarityMax"),
-        "statsId" = VALUES("statsId"),
+        \`rarityMin\` = VALUES(\`rarityMin\`),
+        \`rarityMax\` = VALUES(\`rarityMax\`),
+        \`statsId\` = VALUES(\`statsId\`),
         level = VALUES(level),
         grade = VALUES(grade),
-        "itemRecipeId" = VALUES("itemRecipeId"),
-        layout = VALUES(layout)
+        \`itemRecipeId\` = VALUES(\`itemRecipeId\`),
+        layout = VALUES(layout),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     // Create an array of promises for all insert operations
@@ -358,19 +402,19 @@ async function batchSaveEquipmentToDatabase(items) {
       const batch = items.slice(i, i + batchSize);
       const promises = batch.map((item) => {
         const values = [
-          item.id,
-          item.name,
-          item.typeDescription,
+          item.id ?? null,
+          item.name ?? null,
+          item.typeDescription ?? null,
           JSON.stringify(item.description || []),
-          item.type,
-          item.subType,
+          item.type ?? null,
+          item.subType ?? null,
           JSON.stringify(item.tag || []),
-          item.icon,
-          item.rarityMin,
-          item.rarityMax,
-          item.statsId,
-          item.level,
-          item.grade,
+          item.icon ?? null,
+          item.rarityMin ?? null,
+          item.rarityMax ?? null,
+          item.statsId ?? null,
+          item.level ?? null,
+          item.grade ?? null,
           JSON.stringify(item.itemRecipeId || []),
           item.layout || "equipment",
         ];
@@ -382,12 +426,12 @@ async function batchSaveEquipmentToDatabase(items) {
     }
 
     // Commit the transaction
-    await client.execute("COMMIT");
+    await client.query("COMMIT");
 
     console.log(`Successfully saved ${items.length} items in batch operation`);
   } catch (error) {
     // Rollback in case of error
-    await client.execute("ROLLBACK");
+    await client.query("ROLLBACK");
     console.error(`Error in batch save operation: ${error.message}`);
     throw error;
   } finally {
@@ -406,36 +450,38 @@ async function batchSaveGearToDatabase(items) {
 
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseGear');
     // Begin transaction
-    await client.execute("BEGIN");
+    await client.query("BEGIN");
 
     // Prepare the query
     const query = `
-      INSERT INTO "DatabaseGear" (
-        id, name, "typeDescription", description, type, subtype, tag, icon, "rarityMin", "rarityMax", 
-        slots, "statsId", "setBonusIds", level, grade, "enchantmentId", "deconstructionRecipeId",
-        "itemRecipeId", layout
+      INSERT INTO \`DatabaseGear\` (
+        id, name, \`typeDescription\`, description, type, subtype, tag, icon, \`rarityMin\`, \`rarityMax\`,
+        slots, \`statsId\`, \`setBonusIds\`, level, grade, \`enchantmentId\`, \`deconstructionRecipeId\`,
+        \`itemRecipeId\`, layout
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?)
       ON DUPLICATE KEY UPDATE
         name = VALUES(name),
-        "typeDescription" = VALUES("typeDescription"),
+        \`typeDescription\` = VALUES(\`typeDescription\`),
         description = VALUES(description),
         type = VALUES(type),
         subtype = VALUES(subtype),
         tag = VALUES(tag),
         icon = VALUES(icon),
-        "rarityMin" = VALUES("rarityMin"),
-        "rarityMax" = VALUES("rarityMax"),
+        \`rarityMin\` = VALUES(\`rarityMin\`),
+        \`rarityMax\` = VALUES(\`rarityMax\`),
         slots = VALUES(slots),
-        "statsId" = VALUES("statsId"),
-        "setBonusIds" = VALUES("setBonusIds"),
+        \`statsId\` = VALUES(\`statsId\`),
+        \`setBonusIds\` = VALUES(\`setBonusIds\`),
         level = VALUES(level),
         grade = VALUES(grade),
-        "enchantmentId" = VALUES("enchantmentId"),
-        "deconstructionRecipeId" = VALUES("deconstructionRecipeId"),
-        "itemRecipeId" = VALUES("itemRecipeId"),
-        layout = VALUES(layout)
+        \`enchantmentId\` = VALUES(\`enchantmentId\`),
+        \`deconstructionRecipeId\` = VALUES(\`deconstructionRecipeId\`),
+        \`itemRecipeId\` = VALUES(\`itemRecipeId\`),
+        layout = VALUES(layout),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     // Create an array of promises for all insert operations
@@ -444,23 +490,23 @@ async function batchSaveGearToDatabase(items) {
       const batch = items.slice(i, i + batchSize);
       const promises = batch.map((item) => {
         const values = [
-          item.id,
-          item.name,
-          item.typeDescription,
+          item.id ?? null,
+          item.name ?? null,
+          item.typeDescription ?? null,
           JSON.stringify(item.description || []),
-          item.type,
-          item.subType,
+          item.type ?? null,
+          item.subType ?? null,
           JSON.stringify(item.tag || []),
-          item.icon,
-          item.rarityMin,
-          item.rarityMax,
+          item.icon ?? null,
+          item.rarityMin ?? null,
+          item.rarityMax ?? null,
           JSON.stringify(item.slots || []),
-          item.statsId,
+          item.statsId ?? null,
           JSON.stringify(item.setBonusIds || []),
-          item.level,
-          item.grade,
-          item.enchantmentId,
-          item.deconstructionRecipeId,
+          item.level ?? null,
+          item.grade ?? null,
+          item.enchantmentId ?? null,
+          item.deconstructionRecipeId ?? null,
           JSON.stringify(item.itemRecipeId || []),
           item.layout || "gear",
         ];
@@ -472,12 +518,12 @@ async function batchSaveGearToDatabase(items) {
     }
 
     // Commit the transaction
-    await client.execute("COMMIT");
+    await client.query("COMMIT");
 
     console.log(`Successfully saved ${items.length} items in batch operation`);
   } catch (error) {
     // Rollback in case of error
-    await client.execute("ROLLBACK");
+    await client.query("ROLLBACK");
     console.error(`Error in batch save operation: ${error.message}`);
     throw error;
   } finally {
@@ -541,14 +587,15 @@ async function batchSaveItemsToDatabase(items) {
 
   const client = await pool.getConnection();
   try {
+    await ensureLastModifiedColumn(client, 'DatabaseItems');
     // Begin transaction
-    await client.execute("BEGIN");
+    await client.query("BEGIN");
 
     // Prepare the query
     const query = `
-      INSERT INTO "DatabaseItems" (
-        id, name, description, type, tag, icon, "rarityMin", "rarityMax", level, "statsId",
-        "itemRecipeId", "recipeId", layout, "typeDescription"
+      INSERT INTO \`DatabaseItems\` (
+        id, name, description, type, tag, icon, \`rarityMin\`, \`rarityMax\`, level, \`statsId\`,
+        \`itemRecipeId\`, \`recipeId\`, layout, \`typeDescription\`
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
@@ -557,14 +604,15 @@ async function batchSaveItemsToDatabase(items) {
         type = VALUES(type),
         tag = VALUES(tag),
         icon = VALUES(icon),
-        "rarityMin" = VALUES("rarityMin"),
-        "rarityMax" = VALUES("rarityMax"),
+        \`rarityMin\` = VALUES(\`rarityMin\`),
+        \`rarityMax\` = VALUES(\`rarityMax\`),
         level = VALUES(level),
-        "statsId" = VALUES("statsId"),
-        "itemRecipeId" = VALUES("itemRecipeId"),
-        "recipeId" = VALUES("recipeId"),
+        \`statsId\` = VALUES(\`statsId\`),
+        \`itemRecipeId\` = VALUES(\`itemRecipeId\`),
+        \`recipeId\` = VALUES(\`recipeId\`),
         layout = VALUES(layout),
-        "typeDescription" = VALUES("typeDescription")
+        \`typeDescription\` = VALUES(\`typeDescription\`),
+        lastModified = CURRENT_TIMESTAMP
     `;
 
     // Create an array of promises for all insert operations
@@ -573,16 +621,16 @@ async function batchSaveItemsToDatabase(items) {
       const batch = items.slice(i, i + batchSize);
       const promises = batch.map((item) => {
         const values = [
-          item.id,
-          item.name,
+          item.id ?? null,
+          item.name ?? null,
           JSON.stringify(item.description || []),
-          item.type,
+          item.type ?? null,
           JSON.stringify(item.tag || []),
-          item.icon,
-          item.rarityMin,
-          item.rarityMax,
-          item.level,
-          item.statsId,
+          item.icon ?? null,
+          item.rarityMin ?? null,
+          item.rarityMax ?? null,
+          item.level ?? null,
+          item.statsId ?? null,
           JSON.stringify(item.itemRecipeId || []),
           JSON.stringify(item.recipeId || []),
           item.layout || "item",
@@ -596,12 +644,12 @@ async function batchSaveItemsToDatabase(items) {
     }
 
     // Commit the transaction
-    await client.execute("COMMIT");
+    await client.query("COMMIT");
 
     console.log(`Successfully saved ${items.length} items in batch operation`);
   } catch (error) {
     // Rollback in case of error
-    await client.execute("ROLLBACK");
+    await client.query("ROLLBACK");
     console.error(`Error in batch save operation: ${error.message}`);
     throw error;
   } finally {

--- a/src/processor/recipe.js
+++ b/src/processor/recipe.js
@@ -49,7 +49,7 @@ async function processRecipeFiles(
             learnable: jsonData.learnable,
             overrideName: extractLastQuotedValue(jsonData.overrideName),
             overrides: [],
-            tags: jsonData.categoryTag?.tagName.split(".") || "",
+            tags: jsonData.categoryTag?.tagName?.split(".") || [],
             fuel: jsonData.fuel,
             baseDuration: jsonData.baseDuration,
             rewardId: jsonData.rewardId?.guid || "",


### PR DESCRIPTION
## Summary
- ensure DB tables have `lastModified` timestamp columns
- add helper to update `lastModified` and create columns if missing
- map item recipe scrolls via `learnableRecipeIds` instead of reward IDs
- track modification times when upserting records

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ba94134288322849b89864744f3e6