### PR TITLE
Add crafting recipe lookup for gear items

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -17,6 +17,17 @@ async function ensureLastModifiedColumn(conn, table) {
   }
 }
 
+async function ensureColumnExists(conn, table, columnName, columnType) {
+  const [rows] = await conn.query(
+    `SHOW COLUMNS FROM \`${table}\` LIKE '${columnName}'`
+  );
+  if (rows.length === 0) {
+    await conn.query(
+      `ALTER TABLE \`${table}\` ADD COLUMN \`${columnName}\` ${columnType}`
+    );
+  }
+}
+
 let pool = null;
 
 export async function setupConnection() {
@@ -205,10 +216,12 @@ export async function initDatabase() {
         enchantmentId TEXT,
         deconstructionRecipeId TEXT,
         itemRecipeId JSON,
+        craftingRecipes JSON,
       lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
     await ensureLastModifiedColumn(conn, 'DatabaseGear');
+    await ensureColumnExists(conn, 'DatabaseGear', 'craftingRecipes', 'JSON');
 
     console.log("Database tables initialized");
   } finally {

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -467,9 +467,9 @@ async function batchSaveGearToDatabase(items) {
       INSERT INTO \`DatabaseGear\` (
         id, name, \`typeDescription\`, description, type, subtype, tag, icon, \`rarityMin\`, \`rarityMax\`,
         slots, \`statsId\`, \`setBonusIds\`, level, grade, \`enchantmentId\`, \`deconstructionRecipeId\`,
-        \`itemRecipeId\`, layout
+        \`itemRecipeId\`, \`craftingRecipes\`, layout
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?)
+        ?, ?, ?, ?, ?)
       ON DUPLICATE KEY UPDATE
         name = VALUES(name),
         \`typeDescription\` = VALUES(\`typeDescription\`),
@@ -488,8 +488,31 @@ async function batchSaveGearToDatabase(items) {
         \`enchantmentId\` = VALUES(\`enchantmentId\`),
         \`deconstructionRecipeId\` = VALUES(\`deconstructionRecipeId\`),
         \`itemRecipeId\` = VALUES(\`itemRecipeId\`),
+        \`craftingRecipes\` = VALUES(\`craftingRecipes\`),
         layout = VALUES(layout),
-        lastModified = CURRENT_TIMESTAMP
+        lastModified = IF(
+          name = VALUES(name) AND
+          \`typeDescription\` = VALUES(\`typeDescription\`) AND
+          description = VALUES(description) AND
+          type = VALUES(type) AND
+          subtype = VALUES(subtype) AND
+          tag = VALUES(tag) AND
+          icon = VALUES(icon) AND
+          \`rarityMin\` = VALUES(\`rarityMin\`) AND
+          \`rarityMax\` = VALUES(\`rarityMax\`) AND
+          slots = VALUES(slots) AND
+          \`statsId\` = VALUES(\`statsId\`) AND
+          \`setBonusIds\` = VALUES(\`setBonusIds\`) AND
+          level = VALUES(level) AND
+          grade = VALUES(grade) AND
+          \`enchantmentId\` = VALUES(\`enchantmentId\`) AND
+          \`deconstructionRecipeId\` = VALUES(\`deconstructionRecipeId\`) AND
+          \`itemRecipeId\` = VALUES(\`itemRecipeId\`) AND
+          \`craftingRecipes\` = VALUES(\`craftingRecipes\`) AND
+          layout = VALUES(layout),
+          lastModified,
+          CURRENT_TIMESTAMP
+        )
     `;
 
     // Create an array of promises for all insert operations
@@ -516,6 +539,7 @@ async function batchSaveGearToDatabase(items) {
           item.enchantmentId ?? null,
           item.deconstructionRecipeId ?? null,
           JSON.stringify(item.itemRecipeId || []),
+          JSON.stringify(item.craftingRecipes || []),
           item.layout || "gear",
         ];
         return client.execute(query, values);


### PR DESCRIPTION
## Summary
- fetch crafting recipe data for gear items by scanning reward tables and crafting recipes
- store matched recipes in new `craftingRecipes` column
- ensure database schema adds the new column
- update gear database save logic to conditionally update `lastModified`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865d736063883228ec851a33764bad4