### PR TITLE
Improve item recipe tree parsing for ItemRecord files

### DIFF
--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -17,6 +17,19 @@ async function ensureLastModifiedColumn(client, table) {
   }
 }
 
+async function ensureColumn(client, table, columnName, columnType) {
+  try {
+    const checkQuery = `SHOW COLUMNS FROM \`${table}\` LIKE ?`;
+    const [rows] = await client.query(checkQuery, [columnName]);
+    if (rows.length === 0) {
+      const alterQuery = `ALTER TABLE \`${table}\` ADD COLUMN \`${columnName}\` ${columnType}`;
+      await client.query(alterQuery);
+    }
+  } catch (err) {
+    // Ignore errors such as insufficient permissions
+  }
+}
+
 /**
  * Function to save an item recipe to the MySQL database
  * @param {Object} item - Item object to save
@@ -459,6 +472,7 @@ async function batchSaveGearToDatabase(items) {
   const client = await pool.getConnection();
   try {
     await ensureLastModifiedColumn(client, 'DatabaseGear');
+    await ensureColumn(client, 'DatabaseGear', 'recipeTree', 'JSON');
     // Begin transaction
     await client.query("BEGIN");
 
@@ -467,9 +481,11 @@ async function batchSaveGearToDatabase(items) {
       INSERT INTO \`DatabaseGear\` (
         id, name, \`typeDescription\`, description, type, subtype, tag, icon, \`rarityMin\`, \`rarityMax\`,
         slots, \`statsId\`, \`setBonusIds\`, level, grade, \`enchantmentId\`, \`deconstructionRecipeId\`,
-        \`itemRecipeId\`, \`craftingRecipes\`, layout
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?)
+        \`itemRecipeId\`, \`craftingRecipes\`, \`recipeTree\`, layout
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?
+      )
       ON DUPLICATE KEY UPDATE
         name = VALUES(name),
         \`typeDescription\` = VALUES(\`typeDescription\`),
@@ -489,6 +505,7 @@ async function batchSaveGearToDatabase(items) {
         \`deconstructionRecipeId\` = VALUES(\`deconstructionRecipeId\`),
         \`itemRecipeId\` = VALUES(\`itemRecipeId\`),
         \`craftingRecipes\` = VALUES(\`craftingRecipes\`),
+        \`recipeTree\` = VALUES(\`recipeTree\`),
         layout = VALUES(layout),
         lastModified = IF(
           name = VALUES(name) AND
@@ -509,6 +526,7 @@ async function batchSaveGearToDatabase(items) {
           \`deconstructionRecipeId\` = VALUES(\`deconstructionRecipeId\`) AND
           \`itemRecipeId\` = VALUES(\`itemRecipeId\`) AND
           \`craftingRecipes\` = VALUES(\`craftingRecipes\`) AND
+          \`recipeTree\` = VALUES(\`recipeTree\`) AND
           layout = VALUES(layout),
           lastModified,
           CURRENT_TIMESTAMP
@@ -540,6 +558,7 @@ async function batchSaveGearToDatabase(items) {
           item.deconstructionRecipeId ?? null,
           JSON.stringify(item.itemRecipeId || []),
           JSON.stringify(item.craftingRecipes || []),
+          JSON.stringify(item.recipeTree || {}),
           item.layout || "gear",
         ];
         return client.execute(query, values);


### PR DESCRIPTION
## Summary
- fall back to ItemRecord_<id>.json when loading item data
- use `getItemJson` helper in gear recipe tree builder

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866e4a3d7bc8322a98018325988d1fb