### PR TITLE
Support updated set bonus format

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -116,11 +116,14 @@ export async function initDatabase() {
       CREATE TABLE IF NOT EXISTS DatabaseSetBonuses (
         id VARCHAR(255) PRIMARY KEY,
         name TEXT,
-        setEffects JSON,
+        statBonuses JSON,
+        effectBonuses JSON,
       lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
     await ensureLastModifiedColumn(conn, 'DatabaseSetBonuses');
+    await ensureColumnExists(conn, 'DatabaseSetBonuses', 'statBonuses', 'JSON');
+    await ensureColumnExists(conn, 'DatabaseSetBonuses', 'effectBonuses', 'JSON');
 
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabaseEnchantmentDef (

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -146,15 +146,18 @@ async function saveSetBonusToDatabase(setBonusData) {
   const client = await pool.getConnection();
   try {
     await ensureLastModifiedColumn(client, 'DatabaseSetBonuses');
+    await ensureColumn(client, 'DatabaseSetBonuses', 'statBonuses', 'JSON');
+    await ensureColumn(client, 'DatabaseSetBonuses', 'effectBonuses', 'JSON');
     // Insert into DatabaseSetBonuses table
     const query = `
       INSERT INTO \`DatabaseSetBonuses\` (
-        id, name, \`setEffects\`
+        id, name, \`statBonuses\`, \`effectBonuses\`
       ) VALUES (
-        ?, ?, ?
+        ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
         name = VALUES(name),
-        \`setEffects\` = VALUES(\`setEffects\`),
+        \`statBonuses\` = VALUES(\`statBonuses\`),
+        \`effectBonuses\` = VALUES(\`effectBonuses\`),
         lastModified = CURRENT_TIMESTAMP
     `;
 
@@ -162,7 +165,8 @@ async function saveSetBonusToDatabase(setBonusData) {
     const values = [
       setBonusData.id ?? null,
       setBonusData.name ?? null,
-      JSON.stringify(setBonusData.setEffects || []),
+      JSON.stringify(setBonusData.statBonuses || []),
+      JSON.stringify(setBonusData.effectBonuses || []),
     ];
 
     await client.execute(query, values);

--- a/src/processor/set-bonus.js
+++ b/src/processor/set-bonus.js
@@ -22,19 +22,46 @@ async function processSetBonusFile(filePath, statIdToName) {
     const processedObject = {
       id: jsonData.guid,
       name: extractLastQuotedValue(jsonData.setDisplayName) || "",
-      setEffects: [],
+      statBonuses: [],
+      effectBonuses: [],
     };
 
     // Process each bonus
     if (jsonData.setEffects) {
-      for (const setBonus in jsonData.setEffects) {
-        for (const stat in jsonData.setEffects[setBonus].statEffects) {
-          const id =
-            jsonData.setEffects[setBonus].statEffects[stat].effectedStat.guid;
+      for (const count in jsonData.setEffects) {
+        const effects = jsonData.setEffects[count]?.statEffects || [];
+        for (const bonus of effects) {
+          const id = bonus.effectedStat?.guid;
           const name = statIdToName[id] || "";
-          const stats =
-            jsonData.setEffects[setBonus].statEffects[stat].statEffects;
-          processedObject.setEffects.push({ count: setBonus, id, name, stats });
+          const stats = bonus.statEffects;
+          processedObject.statBonuses.push({ count, id, name, stats });
+        }
+      }
+    }
+
+    if (jsonData.setStatBonuses) {
+      for (const count in jsonData.setStatBonuses) {
+        const bonuses = jsonData.setStatBonuses[count]?.statBonuses || [];
+        for (const bonus of bonuses) {
+          const id = bonus.affectedStat?.guid;
+          const name = statIdToName[id] || "";
+          const stats = bonus.statBonuses;
+          processedObject.statBonuses.push({ count, id, name, stats });
+        }
+      }
+    }
+
+    if (jsonData.setEffectBonuses) {
+      for (const count in jsonData.setEffectBonuses) {
+        const effects = jsonData.setEffectBonuses[count]?.effectBonuses || [];
+        for (const eff of effects) {
+          processedObject.effectBonuses.push({
+            count,
+            effect: eff.effect,
+            minimumRarity: eff.minimumRarity,
+            maximumRarity: eff.maximumRarity,
+            stacks: eff.stacks,
+          });
         }
       }
     }


### PR DESCRIPTION
## Summary
- parse new `setStatBonuses` and `setEffectBonuses`
- store set bonus stats and effects in new DB columns
- create `statBonuses` and `effectBonuses` columns on DB setup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687819f3abcc8322ba3682548a43c79a