### PR TITLE
Support updated set bonus format

### DIFF
--- a/SetBonusModels.cs
+++ b/SetBonusModels.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace AocParser.Models
+{
+    public class SetBonusCollection
+    {
+        public List<SetBonus> SetBonuses { get; set; } = new List<SetBonus>();
+    }
+
+    public class SetBonus
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public List<StatBonus> StatBonuses { get; set; } = new List<StatBonus>();
+        public List<EffectBonus> EffectBonuses { get; set; } = new List<EffectBonus>();
+    }
+
+    public class StatBonus
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Count { get; set; }
+        public BonusValues Stats { get; set; } = new BonusValues();
+    }
+
+    public class BonusValues
+    {
+        public double Epic { get; set; }
+        public double Rare { get; set; }
+        public double Common { get; set; }
+        public double Heroic { get; set; }
+        public double Artifact { get; set; }
+        public double Uncommon { get; set; }
+        public double Legendary { get; set; }
+    }
+
+    public class EffectBonus
+    {
+        public string Count { get; set; }
+        public BonusEffect Effect { get; set; } = new BonusEffect();
+        public string MinimumRarity { get; set; }
+        public string MaximumRarity { get; set; }
+        public int Stacks { get; set; }
+    }
+
+    public class BonusEffect
+    {
+        public string Id { get; set; }
+        public string TypeId { get; set; }
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/db/config.js
+++ b/src/db/config.js
@@ -116,11 +116,14 @@ export async function initDatabase() {
       CREATE TABLE IF NOT EXISTS DatabaseSetBonuses (
         id VARCHAR(255) PRIMARY KEY,
         name TEXT,
-        setEffects JSON,
+        statBonuses JSON,
+        effectBonuses JSON,
       lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
     await ensureLastModifiedColumn(conn, 'DatabaseSetBonuses');
+    await ensureColumnExists(conn, 'DatabaseSetBonuses', 'statBonuses', 'JSON');
+    await ensureColumnExists(conn, 'DatabaseSetBonuses', 'effectBonuses', 'JSON');
 
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabaseEnchantmentDef (

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -146,15 +146,18 @@ async function saveSetBonusToDatabase(setBonusData) {
   const client = await pool.getConnection();
   try {
     await ensureLastModifiedColumn(client, 'DatabaseSetBonuses');
+    await ensureColumn(client, 'DatabaseSetBonuses', 'statBonuses', 'JSON');
+    await ensureColumn(client, 'DatabaseSetBonuses', 'effectBonuses', 'JSON');
     // Insert into DatabaseSetBonuses table
     const query = `
       INSERT INTO \`DatabaseSetBonuses\` (
-        id, name, \`setEffects\`
+        id, name, \`statBonuses\`, \`effectBonuses\`
       ) VALUES (
-        ?, ?, ?
+        ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
         name = VALUES(name),
-        \`setEffects\` = VALUES(\`setEffects\`),
+        \`statBonuses\` = VALUES(\`statBonuses\`),
+        \`effectBonuses\` = VALUES(\`effectBonuses\`),
         lastModified = CURRENT_TIMESTAMP
     `;
 
@@ -162,7 +165,8 @@ async function saveSetBonusToDatabase(setBonusData) {
     const values = [
       setBonusData.id ?? null,
       setBonusData.name ?? null,
-      JSON.stringify(setBonusData.setEffects || []),
+      JSON.stringify(setBonusData.statBonuses || []),
+      JSON.stringify(setBonusData.effectBonuses || []),
     ];
 
     await client.execute(query, values);

--- a/src/processor/set-bonus.js
+++ b/src/processor/set-bonus.js
@@ -5,7 +5,7 @@
 import fs from "fs";
 import path from "path";
 import { saveSetBonusToDatabase } from "../db/operations.js";
-import { extractLastQuotedValue } from "../utils.js";
+import { extractLastQuotedValue, getJson, parseValueExpression } from "../utils.js";
 
 /**
  * Processes a single JSON file containing set bonus data
@@ -13,7 +13,7 @@ import { extractLastQuotedValue } from "../utils.js";
  * @param {Object} statIdToName - Mapping of stat IDs to names
  * @returns {Object|null} Processed data object or null if processing failed
  */
-async function processSetBonusFile(filePath, statIdToName) {
+async function processSetBonusFile(filePath, statIdToName, dataDir) {
   try {
     const rawData = await fs.promises.readFile(filePath, "utf8");
     const jsonData = JSON.parse(rawData);
@@ -22,19 +22,93 @@ async function processSetBonusFile(filePath, statIdToName) {
     const processedObject = {
       id: jsonData.guid,
       name: extractLastQuotedValue(jsonData.setDisplayName) || "",
-      setEffects: [],
+      statBonuses: [],
+      effectBonuses: [],
     };
 
     // Process each bonus
     if (jsonData.setEffects) {
-      for (const setBonus in jsonData.setEffects) {
-        for (const stat in jsonData.setEffects[setBonus].statEffects) {
-          const id =
-            jsonData.setEffects[setBonus].statEffects[stat].effectedStat.guid;
+      for (const count in jsonData.setEffects) {
+        const effects = jsonData.setEffects[count]?.statEffects || [];
+        for (const bonus of effects) {
+          const id = bonus.effectedStat?.guid;
           const name = statIdToName[id] || "";
-          const stats =
-            jsonData.setEffects[setBonus].statEffects[stat].statEffects;
-          processedObject.setEffects.push({ count: setBonus, id, name, stats });
+          const stats = bonus.statEffects;
+          processedObject.statBonuses.push({ count, id, name, stats });
+        }
+      }
+    }
+
+    if (jsonData.setStatBonuses) {
+      for (const count in jsonData.setStatBonuses) {
+        const bonuses = jsonData.setStatBonuses[count]?.statBonuses || [];
+        for (const bonus of bonuses) {
+          const id = bonus.affectedStat?.guid;
+          const name = statIdToName[id] || "";
+          const stats = bonus.statBonuses;
+          processedObject.statBonuses.push({ count, id, name, stats });
+        }
+      }
+    }
+
+    if (jsonData.setEffectBonuses) {
+      for (const count in jsonData.setEffectBonuses) {
+        const effects = jsonData.setEffectBonuses[count]?.effectBonuses || [];
+        for (const eff of effects) {
+          const effectId = eff.effect?.guid;
+          if (!effectId) continue;
+          let effectData = getJson(
+            dataDir,
+            "/Effects/Effect",
+            `Effect_${effectId}.json`
+          );
+          if (!effectData || Object.keys(effectData).length === 0) {
+            effectData = getJson(
+              dataDir,
+              "/Effects/Effect",
+              `EffectRecord_${effectId}.json`
+            );
+          }
+
+          const statMods = effectData.statModsIds || [];
+          for (const mod of statMods) {
+            const modId = mod.guid;
+            let modData = getJson(
+              dataDir,
+              "/Effects/StatMod",
+              `StatMod_${modId}.json`
+            );
+            if (!modData || Object.keys(modData).length === 0) {
+              modData = getJson(
+                dataDir,
+                "/Effects/StatMod",
+                `StatModRecord_${modId}.json`
+              );
+            }
+
+            const statId = modData.statRefId?.guid;
+            const statName = statIdToName[statId] || "";
+            const value = parseValueExpression(
+              modData.value?.expression || "",
+              modData.valueInputTerms || [],
+              statIdToName,
+              dataDir
+            );
+
+            const effectObj = {
+              ...eff.effect,
+              name: statName,
+              value,
+            };
+
+            processedObject.effectBonuses.push({
+              count,
+              effect: effectObj,
+              minimumRarity: eff.minimumRarity,
+              maximumRarity: eff.maximumRarity,
+              stacks: eff.stacks,
+            });
+          }
         }
       }
     }
@@ -74,10 +148,16 @@ async function processSetBonusFiles(directoryPath, statIdToName) {
     console.log(`Found ${jsonFiles.length} set bonus files to process`);
     let successCount = 0;
 
+    const dataDir = path.resolve(directoryPath, "..", "..");
+
     // Process each JSON file
     for (const file of jsonFiles) {
       const filePath = path.join(directoryPath, file);
-      const processedData = await processSetBonusFile(filePath, statIdToName);
+      const processedData = await processSetBonusFile(
+        filePath,
+        statIdToName,
+        dataDir
+      );
 
       if (processedData !== null) {
         // Save to database

--- a/src/utils.js
+++ b/src/utils.js
@@ -325,6 +325,66 @@ function extractExpressionId(str) {
 }
 
 /**
+ * Parse a stat modifier expression, resolving GetTerm and GetStat calls.
+ * @param {string} expression - Raw expression string
+ * @param {Array} valueInputTerms - Optional term overrides
+ * @param {Object} statIdToName - Mapping of stat guids to names
+ * @param {string} dataDir - Base directory for JSON lookups
+ * @returns {string} Parsed expression
+ */
+function parseValueExpression(
+  expression,
+  valueInputTerms = [],
+  statIdToName = {},
+  dataDir = ""
+) {
+  if (!expression) return "";
+
+  // Resolve EvalE($#type:id$) references to the equation expression
+  expression = expression.replace(/EvalE\(\$#\d+:(\d+)\$\)/g, (m, id) => {
+    let eq = getJson(dataDir, "/Stats/StatEquationType", `StatEquationType_${id}.json`);
+    if (!eq || Object.keys(eq).length === 0) {
+      eq = getJson(dataDir, "/Stats/StatEquationType", `StatEquationTypeRecord_${id}.json`);
+    }
+    return eq.equation?.expression || "";
+  });
+
+  // Map term guid -> value from valueInputTerms
+  const termMap = {};
+  if (Array.isArray(valueInputTerms)) {
+    for (const term of valueInputTerms) {
+      const guid = term.termId?.guid;
+      if (!guid) continue;
+      let val = term.value?.expression || "";
+      // Recursively resolve nested EvalE calls
+      val = parseValueExpression(val, [], statIdToName, dataDir);
+      termMap[guid] = val;
+    }
+  }
+
+  // Replace GetTerm references
+  expression = expression.replace(/GetTerm\(\$#\d+:(\d+)\$\)/g, (m, id) => {
+    if (termMap[id] !== undefined) return termMap[id];
+    let term = getJson(dataDir, "/Stats/Term", `Term_${id}.json`);
+    if (!term || Object.keys(term).length === 0) {
+      term = getJson(dataDir, "/Stats/Term", `TermRecord_${id}.json`);
+    }
+    return term.defaultValue?.expression || "";
+  });
+
+  // Replace GetStat/ConsumedItemStat references with stat names
+  expression = expression.replace(
+    /(GetStat\([^,]*,\s*\$#\d+:(\d+)\$\))|(GetConsumedItemStat\(\$#\d+:(\d+)\$\))/g,
+    (m, s1, id1, s2, id2) => {
+      const guid = id1 || id2;
+      return statIdToName[guid] || guid;
+    }
+  );
+
+  return expression;
+}
+
+/**
  * Formats a given number of seconds into a human-readable time string
  * @param {string} seconds - Number of seconds
  * @returns {string} A string representing the time in seconds, minutes, or hours
@@ -356,5 +416,6 @@ export {
   logMissingIcon,
   createEmptyStatsObject,
   extractExpressionId,
+  parseValueExpression,
   formatTime,
 };


### PR DESCRIPTION
## Summary
- parse new `setStatBonuses` and `setEffectBonuses`
- store set bonus stats and effects in new DB columns
- create `statBonuses` and `effectBonuses` columns on DB setup
- add C# models for consuming updated set bonus JSON
- parse effect bonuses to include stat names and values
- **fix** effect bonuses so stat name/value are embedded in the `effect` object
- fully resolve expressions in effect bonus values

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687819f3abcc8322ba3682548a43c79a