### PR TITLE
Add player stat extraction

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -245,6 +245,15 @@ export async function initDatabase() {
     `);
     await ensureLastModifiedColumn(conn, 'DatabaseLootInfo');
 
+    await conn.query(`
+      CREATE TABLE IF NOT EXISTS DatabasePlayerStats (
+        class INT PRIMARY KEY,
+        className TEXT,
+      lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      )
+    `);
+    await ensureLastModifiedColumn(conn, 'DatabasePlayerStats');
+
     console.log("Database tables initialized");
   } finally {
     conn.release();

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -755,6 +755,29 @@ async function saveLootInfoToDatabase(loot) {
   }
 }
 
+async function savePlayerStatsToDatabase(playerStats) {
+  const client = await pool.getConnection();
+  try {
+    await ensureLastModifiedColumn(client, 'DatabasePlayerStats');
+    const attributes = playerStats.attributes || {};
+    for (const attr of Object.keys(attributes)) {
+      await ensureColumn(client, 'DatabasePlayerStats', `\`${attr}\``, 'JSON');
+    }
+    const columns = ['class', 'className', ...Object.keys(attributes).map(a => `\`${a}\``)];
+    const placeholders = columns.map(() => '?').join(', ');
+    const updates = columns.slice(1).map(c => `${c} = VALUES(${c})`).join(', ');
+    const values = [
+      playerStats.class,
+      playerStats.className,
+      ...Object.values(attributes).map(v => JSON.stringify(v)),
+    ];
+    const query = `INSERT INTO \`DatabasePlayerStats\` (${columns.join(', ')}) VALUES (${placeholders}) ON DUPLICATE KEY UPDATE ${updates}, lastModified = CURRENT_TIMESTAMP`;
+    await client.execute(query, values);
+  } finally {
+    client.release();
+  }
+}
+
 export {
   saveItemRecipeToDatabase,
   saveStatToDatabase,
@@ -768,4 +791,5 @@ export {
   batchFindRecipes,
   batchSaveItemsToDatabase,
   saveLootInfoToDatabase,
+  savePlayerStatsToDatabase,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import { processEnchantmentDefFiles } from "./processor/enchantment-def.js";
 import { processEnchantmentLevelFiles } from "./processor/enchantment-level.js";
 import { processRecipeFiles } from "./processor/recipe.js";
 import { processLootFiles } from "./processor/loot.js";
+import { processPlayerStats } from "./processor/player-stats.js";
 import {
   directoryStats,
   directorySetBonus,
@@ -152,6 +153,12 @@ async function main() {
     const equipmentProcessed = await processItemEquipmentFiles(directoryData);
     console.log(
       `Item:Equipment processing complete: ${equipmentProcessed} files processed`
+    );
+
+    console.log("\nProcessing player stat files...");
+    const playerStatsProcessed = await processPlayerStats(directoryData, statIdToName);
+    console.log(
+      `Player stats processing complete: ${playerStatsProcessed} classes processed`
     );
 
     console.log("\nProcessing loot files...");

--- a/src/processor/player-stats.js
+++ b/src/processor/player-stats.js
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { savePlayerStatsToDatabase } from '../db/operations.js';
+import { extractExpressionId } from '../utils.js';
+
+const classFiles = [
+  { value: 0, name: 'Bard', file: 'StatInitializerList_6064630736345890821.json' },
+  { value: 1, name: 'Cleric', file: 'StatInitializerList_6064630372724375553.json' },
+  { value: 2, name: 'Fighter', file: 'StatInitializerList_6064630372725096450.json' },
+  { value: 3, name: 'Mage', file: 'StatInitializerList_6064630533573115931.json' },
+  { value: 4, name: 'Ranger', file: 'StatInitializerList_6064630533572591642.json' },
+  { value: 5, name: 'Rogue', file: 'StatInitializerList_6064632655562356508.json' },
+  { value: 6, name: 'Summoner', file: 'StatInitializerList_6064632655604299549.json' },
+  { value: 7, name: 'Tank', file: 'StatInitializerList_6064630372720508928.json' },
+];
+
+function sanitize(name) {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+async function processClass(dataDir, cls, statIdToName) {
+  const filePath = path.join(
+    dataDir,
+    'Stats',
+    'StatInitializerList',
+    cls.file
+  );
+  const raw = await fs.promises.readFile(filePath, 'utf8');
+  const json = JSON.parse(raw);
+  const attrs = {};
+  for (const entry of json.statIds || []) {
+    const guid = entry.statId?.guid;
+    const expr = entry.valueExpression?.expression || '';
+    if (!guid || !expr.includes('EvalCurve')) continue;
+    const name = sanitize(statIdToName[guid] || guid);
+    const curveId = extractExpressionId(expr);
+    if (!curveId) continue;
+    const curvePath = path.join(
+      dataDir,
+      'Stats',
+      'StatCurve',
+      `StatCurve_${curveId}.json`
+    );
+    let curve;
+    try {
+      curve = JSON.parse(await fs.promises.readFile(curvePath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const keys = curve.curve?.editorCurveData?.keys || [];
+    const multMatch = expr.match(/\*\s*(-?\d+(?:\.\d+)?)/);
+    const multiplier = multMatch ? parseFloat(multMatch[1]) : 1;
+    const useRound = expr.includes('Round(');
+    const useRunning = expr.includes('GetStatInitRunningTotal');
+    const levels = {};
+    let total = 0;
+    for (const k of keys) {
+      const lvl = k.time;
+      let val = k.value * multiplier;
+      if (useRound) val = Math.round(val);
+      if (useRunning) {
+        total += val;
+        levels[lvl] = Math.round(total);
+      } else {
+        levels[lvl] = val;
+      }
+    }
+    attrs[name] = levels;
+  }
+  await savePlayerStatsToDatabase({
+    class: cls.value,
+    className: cls.name,
+    attributes: attrs,
+  });
+}
+
+async function processPlayerStats(directoryPath, statIdToName) {
+  for (const cls of classFiles) {
+    await processClass(directoryPath, cls, statIdToName);
+  }
+  return classFiles.length;
+}
+
+export { processPlayerStats };


### PR DESCRIPTION
## Summary
- add `DatabasePlayerStats` table creation
- store class stats via new `savePlayerStatsToDatabase`
- add processor to read stat initializer lists and curves
- integrate player stat processing in the main parser

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68830c33f7dc8322a09ea30f500818be