### PR TITLE
Improve skill table formatting

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -259,6 +259,26 @@ export async function initDatabase() {
     `);
     await ensureLastModifiedColumn(conn, 'DatabasePlayerStats');
 
+    await conn.query(`
+      CREATE TABLE IF NOT EXISTS DatabaseSkillTable (
+        id VARCHAR(255) PRIMARY KEY,
+        tableId VARCHAR(255),
+        tableName TEXT,
+        name TEXT,
+        description TEXT,
+        type TEXT,
+        cooldown DOUBLE,
+        manaCost JSON,
+        maxRank INT,
+        imageUrl TEXT,
+        position JSON,
+        requirements JSON,
+      lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      )
+    `);
+    await ensureLastModifiedColumn(conn, 'DatabaseSkillTable');
+    await ensureColumnExists(conn, 'DatabaseSkillTable', 'manaCost', 'JSON');
+
     console.log("Database tables initialized");
   } finally {
     conn.release();

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -782,6 +782,68 @@ async function savePlayerStatsToDatabase(playerStats) {
   }
 }
 
+async function batchSaveSkillTableToDatabase(entries) {
+  if (!entries || entries.length === 0) {
+    return;
+  }
+
+  const client = await pool.getConnection();
+  try {
+    await ensureLastModifiedColumn(client, 'DatabaseSkillTable');
+    await client.query('BEGIN');
+    const query = `
+      INSERT INTO \`DatabaseSkillTable\` (
+        id, tableId, tableName, name, description, type, cooldown, manaCost, maxRank,
+        imageUrl, position, requirements
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+      ) ON DUPLICATE KEY UPDATE
+        tableId = VALUES(tableId),
+        tableName = VALUES(tableName),
+        name = VALUES(name),
+        description = VALUES(description),
+        type = VALUES(type),
+        cooldown = VALUES(cooldown),
+        manaCost = VALUES(manaCost),
+        maxRank = VALUES(maxRank),
+        imageUrl = VALUES(imageUrl),
+        position = VALUES(position),
+        requirements = VALUES(requirements),
+        lastModified = CURRENT_TIMESTAMP
+    `;
+    const batchSize = 100;
+    for (let i = 0; i < entries.length; i += batchSize) {
+      const batch = entries.slice(i, i + batchSize);
+      const promises = batch.map((e) => {
+        const values = [
+          e.id ?? null,
+          e.tableId ?? null,
+          e.tableName ?? null,
+          e.name ?? null,
+          e.description ?? null,
+          e.type ?? null,
+          e.cooldown ?? null,
+          JSON.stringify(e.manaCost || {}),
+          e.maxRank ?? null,
+          e.imageUrl ?? null,
+          JSON.stringify(e.position || {}),
+          JSON.stringify(e.requirements || {})
+        ];
+        return client.execute(query, values);
+      });
+      await Promise.all(promises);
+    }
+    await client.query('COMMIT');
+    console.log(`Successfully saved ${entries.length} skill entries in batch operation`);
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`Error in batch save operation: ${error.message}`);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 export {
   saveItemRecipeToDatabase,
   saveStatToDatabase,
@@ -796,4 +858,5 @@ export {
   batchSaveItemsToDatabase,
   saveLootInfoToDatabase,
   savePlayerStatsToDatabase,
+  batchSaveSkillTableToDatabase,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import { processEnchantmentDefFiles } from "./processor/enchantment-def.js";
 import { processEnchantmentLevelFiles } from "./processor/enchantment-level.js";
 import { processRecipeFiles } from "./processor/recipe.js";
 import { processLootFiles } from "./processor/loot.js";
+import { processSkillTables } from "./processor/skill-table.js";
 import { processPlayerStats } from "./processor/player-stats.js";
 import {
   directoryStats,
@@ -164,6 +165,10 @@ async function main() {
     console.log("\nProcessing loot files...");
     const lootProcessed = await processLootFiles(directoryData);
     console.log(`Loot processing complete: ${lootProcessed} entries saved`);
+
+    console.log("\nProcessing skill tables...");
+    const skillsProcessed = await processSkillTables(directoryData);
+    console.log(`Skill tables processing complete: ${skillsProcessed} entries saved`);
 
     console.log("\nAll processing complete. Closing connections...");
   } catch (error) {

--- a/src/processor/skill-table.js
+++ b/src/processor/skill-table.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+import { parseSkillTable } from '../tools/parse-skill-table.js';
+import { batchSaveSkillTableToDatabase } from '../db/operations.js';
+import { extractLastQuotedValue } from '../utils.js';
+
+const CLASS_NAMES = ['Fighter','Tank','Cleric','Bard','Mage','Ranger','Rogue','Summoner'];
+
+async function processSkillTables(directoryData) {
+  const dir = path.join(directoryData, 'SkillTree/SkillTree');
+  const files = fs.readdirSync(dir).filter(f => f.startsWith('SkillTable_') && f.endsWith('.json'));
+  const allSkills = [];
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const tableData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const tableName = extractLastQuotedValue(tableData.displayName || tableData.name);
+    if (!tableName) continue;
+    if (!CLASS_NAMES.includes(tableName) && !tableName.startsWith('Weapon_')) continue;
+    if (tableName.includes('_Stage')) continue;
+    const match = file.match(/SkillTable_(\d+)/);
+    if (!match) continue;
+    const tableId = match[1];
+    const skills = parseSkillTable(tableId, directoryData);
+    for (const s of skills) {
+      s.tableId = tableId;
+      s.tableName = tableName;
+    }
+    allSkills.push(...skills);
+  }
+  await batchSaveSkillTableToDatabase(allSkills);
+  console.log(`Successfully processed ${allSkills.length} skills from skill tables`);
+  return allSkills.length;
+}
+
+export { processSkillTables };

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -1,0 +1,369 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { extractLastQuotedValue } from '../utils.js';
+
+function findJsonFile(dir, prefix, id) {
+  const direct = path.join(dir, `${prefix}_${id}.json`);
+  if (fs.existsSync(direct)) return direct;
+  const files = fs.readdirSync(dir);
+  const match = files.find(f => f.includes(id));
+  return match ? path.join(dir, match) : null;
+}
+
+function loadJson(baseDir, subDir, prefix, id) {
+  const dir = path.join(baseDir, subDir);
+  let file = findJsonFile(dir, prefix, id);
+  if (!file && prefix) {
+    file = findJsonFile(dir, `${prefix}Record`, id);
+  }
+  if (!file) {
+    const candidate = fs
+      .readdirSync(dir)
+      .find((f) => f.endsWith('.json') && fs.readFileSync(path.join(dir, f), 'utf8').includes(id));
+    if (candidate) file = path.join(dir, candidate);
+  }
+  if (!file) return {};
+  const data = fs.readFileSync(file, 'utf8');
+  return JSON.parse(data);
+}
+
+function parseCurve(curveData) {
+  const keys =
+    curveData?.curve?.editorCurveData?.keys || [];
+  const result = {};
+  for (const k of keys) {
+    const lvl = parseInt(k.time, 10);
+    if (!Number.isNaN(lvl)) {
+      result[lvl] = k.value;
+    }
+  }
+  return result;
+}
+
+const CLASS_PREFIXES = ['Fighter','Tank','Cleric','Bard','Mage','Ranger','Rogue','Summoner','Weapon'];
+
+function formatEffectName(name) {
+  if (!name) return '';
+  let out = name
+    .replace(/^Status_/, '')
+    .replace(/^Effect_/, '')
+    .replace(/^Weapon_Description_/, '')
+    .replace(/^Weapon_/, '')
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2');
+  for (const p of CLASS_PREFIXES) {
+    if (out.startsWith(p + ' ')) {
+      out = out.slice(p.length + 1);
+      break;
+    }
+  }
+  out = out.replace(/\b[Ss]tat\b/, '').trim();
+  return out;
+}
+
+function parseManaCost(ability, dataDir) {
+  let costsArray = ability.statCosts || [];
+  if ((!costsArray || costsArray.length === 0) && Array.isArray(ability.costs)) {
+    const first = ability.costs[0];
+    if (first && Array.isArray(first.statCosts)) {
+      costsArray = first.statCosts;
+    }
+  }
+  const entry = (costsArray || []).find(
+    (c) =>
+      c.stat?.name === 'Stat_Mana' ||
+      c.stat?.guid === '109183576135288'
+  );
+  if (!entry) return null;
+  const expr = entry.value?.expression || '';
+  const constant = parseFloat(expr);
+  if (!Number.isNaN(constant)) {
+    const costs = {};
+    for (let i = 1; i <= 50; i++) costs[i] = constant;
+    return costs;
+  }
+  const multMatch = expr.match(/([0-9.]+)\s*\*\s*EvalFormula\([^:]+:(\d+)/);
+  const evalMatch = expr.match(/EvalFormula\([^:]+:(\d+)/);
+  const formulaGuid = multMatch ? multMatch[2] : evalMatch ? evalMatch[1] : null;
+  const mult = multMatch ? parseFloat(multMatch[1]) : 1;
+  if (!formulaGuid) return null;
+  const formula = loadJson(
+    dataDir,
+    'Stats/StatFormulaType',
+    'StatFormulaType',
+    formulaGuid
+  );
+  const eqGuid = formula.equationId?.guid;
+  const equation = loadJson(
+    dataDir,
+    'Stats/StatEquationType',
+    'StatEquationType',
+    eqGuid
+  );
+  const eqExpr = equation.equation?.expression || '';
+  const curveMatch = eqExpr.match(/EvalCurve\([^:]+:(\d+)/);
+  const divMatch = eqExpr.match(/\/([0-9.]+)\s*$/);
+  const div = divMatch ? parseFloat(divMatch[1]) : 1;
+  const curveGuid = curveMatch ? curveMatch[1] : null;
+  if (!curveGuid) return null;
+  const curve = loadJson(
+    dataDir,
+    'Stats/StatCurve',
+    'StatCurve',
+    curveGuid
+  );
+  const curveVals = parseCurve(curve);
+  const costs = {};
+  for (const [lvlStr, val] of Object.entries(curveVals)) {
+    const lvl = parseInt(lvlStr, 10);
+    costs[lvl] = Math.round(mult * (val / div));
+  }
+  return costs;
+}
+
+function parseDamage(hitGuid, dataDir) {
+  let hit = loadJson(dataDir, 'Abilities/AbilityHit', 'AbilityHit', hitGuid);
+  if (!hit || Object.keys(hit).length === 0) {
+    // attempt lookup by name
+    const dir = path.join(dataDir, 'Abilities/AbilityHit');
+    const file = fs
+      .readdirSync(dir)
+      .find((f) => fs.readFileSync(path.join(dir, f), 'utf8').includes(`"name": "${hitGuid}"`));
+    if (file) {
+      hit = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+    } else {
+      return null;
+    }
+  }
+  const elementTag = hit.eventTags?.[0]?.tagName || '';
+  const element = elementTag.split('.').pop();
+  const statGuid = hit.statModsIds?.[0]?.guid;
+  let percent = null;
+  if (statGuid) {
+    const mod = loadJson(dataDir, 'Effects/StatMod', 'StatMod', statGuid);
+    const modAlt = Object.keys(mod).length ? mod : loadJson(dataDir, 'Effects/StatMod', '', statGuid);
+    const expr = modAlt.valueInputTerms?.[0]?.value?.expression || modAlt.value?.expression;
+    if (expr) {
+      const v = parseFloat(expr);
+      if (!Number.isNaN(v)) percent = v * 100;
+    }
+  }
+  return { element, percent };
+}
+
+function parseDamageRange(hitKey, part, dataDir) {
+  const hit = loadAbilityHit(hitKey, dataDir);
+  if (!hit) return null;
+  const elementTag = hit.eventTags?.[0]?.tagName || '';
+  const element = elementTag.split('.').pop();
+  const statGuid = hit.statModsIds?.[0]?.guid;
+  if (!statGuid) return null;
+  const mod = loadJson(dataDir, 'Effects/StatMod', 'StatMod', statGuid);
+  const modAlt = Object.keys(mod).length ? mod : loadJson(dataDir, 'Effects/StatMod', '', statGuid);
+  const terms = modAlt.valueInputTerms || [];
+  const idx = part === 'min' ? 0 : part === 'max' ? 1 : -1;
+  if (idx < 0 || !terms[idx]) return null;
+  const val = parseFloat(terms[idx].value?.expression);
+  if (Number.isNaN(val)) return null;
+  return `${val * 100}% ${element} Damage`;
+}
+
+function parseLingerTick(name, dataDir) {
+  const dir = path.join(dataDir, 'Abilities/LingeringEffect');
+  let file = findJsonFile(dir, 'LingeringEffect', name);
+  if (!file) {
+    const match = fs.readdirSync(dir).find(f => fs.readFileSync(path.join(dir, f), 'utf8').includes(`"name": "${name}"`));
+    if (match) file = path.join(dir, match);
+  }
+  if (!file) return null;
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const rate = data.tickRate || 0;
+  return rate ? `${rate} second${rate === 1 ? '' : 's'}` : null;
+}
+
+function loadAbilityHit(hitKey, dataDir) {
+  let hit = loadJson(dataDir, 'Abilities/AbilityHit', 'AbilityHit', hitKey);
+  if (!hit || Object.keys(hit).length === 0) {
+    const dir = path.join(dataDir, 'Abilities/AbilityHit');
+    const file = fs
+      .readdirSync(dir)
+      .find((f) => fs.readFileSync(path.join(dir, f), 'utf8').includes(`"name": "${hitKey}"`));
+    if (file) {
+      hit = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+    }
+  }
+  return hit;
+}
+
+function parseApplyEffectName(hitKey, index, dataDir) {
+  const hit = loadAbilityHit(hitKey, dataDir);
+  if (!hit || !Array.isArray(hit.applyEffects)) return null;
+  const effGuid = hit.applyEffects[index]?.effectId?.guid;
+  if (!effGuid || effGuid === '0') return null;
+  const eff = loadJson(dataDir, 'Effects/Effect', 'Effect', effGuid);
+  const effName = extractLastQuotedValue(eff.effectName);
+  return effName ? formatEffectName(effName) : null;
+}
+
+function formatDescription(desc, ability, dataDir) {
+  let text = extractLastQuotedValue(desc);
+  if (ability.hitsIds && ability.hitsIds['1']) {
+    const dmg = parseDamage(ability.hitsIds['1'].guid, dataDir);
+    if (dmg && dmg.percent) {
+      const dmgStr = `${dmg.percent}% ${dmg.element} Damage`;
+      text = text.replace('$hit1$', dmgStr);
+    }
+  }
+  // replace hit tokens with computed damage when possible
+  text = text.replace(/\$hit(\d+)(?:\.[^$]+)?\$/g, (m, n) => {
+    const id = ability.hitsIds?.[n]?.guid;
+    if (!id) return m;
+    const dmg = parseDamage(id, dataDir);
+    return dmg && dmg.percent ? `${dmg.percent}% ${dmg.element} Damage` : m;
+  });
+
+  text = text.replace(/\$hit:([^\.]+)\.min\$/g, (m, name) => {
+    const val = parseDamageRange(name, 'min', dataDir);
+    return val || m;
+  });
+
+  text = text.replace(/\$hit:([^\.]+)\.max\$/g, (m, name) => {
+    const val = parseDamageRange(name, 'max', dataDir);
+    return val || m;
+  });
+
+  text = text.replace(/\$hit(\d+):apply(\d+)(?:\.[^$]+)?\$/g, (m, hitNum, idx) => {
+    const id = ability.hitsIds?.[hitNum]?.guid;
+    if (!id) return '';
+    const eff = parseApplyEffectName(id, parseInt(idx, 10), dataDir);
+    return eff ? `[${eff}]` : '';
+  });
+
+  text = text.replace(/\$hit(\d+)\.apply(\d+)(?:fordur)?(?:\.[^$]+)?\$/g, (m, hitNum, idx) => {
+    const id = ability.hitsIds?.[hitNum]?.guid;
+    if (!id) return '';
+    const eff = parseApplyEffectName(id, parseInt(idx, 10), dataDir);
+    return eff ? `[${eff}]` : '';
+  });
+
+  text = text.replace(/\$hit:([^\.]+)\.apply(\d+)(?:fordur)?\$/g, (m, name, idx) => {
+    const eff = parseApplyEffectName(name, parseInt(idx, 10), dataDir);
+    return eff ? `[${eff}]` : '';
+  });
+
+  text = text.replace(/\{hit:([^\.\}]+)\.apply(\d+)\}/g, (m, name, idx) => {
+    const eff = parseApplyEffectName(name, parseInt(idx, 10), dataDir);
+    return eff ? `[${eff}]` : '';
+  });
+
+  text = text.replace(/\{hit:([^\.\}]+)(?:\.[^\}]+)?\}/g, (m, name) => {
+    const dmg = parseDamage(name, dataDir);
+    return dmg && dmg.percent ? `${dmg.percent}% ${dmg.element} Damage` : '';
+  });
+
+  text = text.replace(/\$linger:([^\.]+)\.tick\$/g, (m, name) => {
+    const val = parseLingerTick(name, dataDir);
+    return val || m;
+  });
+
+  text = text.replace(/\$effect(\d+)(?:\.[^$]+)?\$/g, (m, idx) => {
+    const guid = ability.effectsIds?.[idx]?.guid;
+    if (!guid) return '';
+    const eff = loadJson(dataDir, 'Effects/Effect', 'Effect', guid);
+    const name = formatEffectName(extractLastQuotedValue(eff.effectName));
+    return name ? `[${name}]` : '';
+  });
+
+  text = text.replace(/\{effect(\d+)(?:\.[^\}]+)?\}/g, (m, idx) => {
+    const guid = ability.effectsIds?.[idx]?.guid;
+    if (!guid) return '';
+    const eff = loadJson(dataDir, 'Effects/Effect', 'Effect', guid);
+    const name = formatEffectName(extractLastQuotedValue(eff.effectName));
+    return name ? `[${name}]` : '';
+  });
+
+  const effRegex = /\$effect:([^\.\$]+)(?:\.[^\$]+)?\$|\{effect:([^\.\}]+)(?:\.[^\}]+)?\}/g;
+  text = text.replace(effRegex, (_, e1, e2) => `[${formatEffectName(e1 || e2)}]`);
+
+  text = text.replace(/\{skill:[^\}]*\}/g, '');
+  text = text.replace(/rnrn/g, '  ');
+  text = text.replace(/\r\n|\n/g, ' ');
+  text = text.replace(/<img[^>]*id=\"([^\"]+)\"[^>]*>/g, (_, id) => `[${formatEffectName(id)}]`);
+  text = text.replace(/\((\s*\[[^\]]+\]\s*)+\)/g, (m) => m.slice(1, -1));
+  text = text.replace(/Healing Damage/gi, 'Healing');
+  text = text.replace(/\s+/g, ' ').trim();
+  return text;
+}
+
+function parseSkillTable(id, dataDir) {
+  const table = loadJson(dataDir, 'SkillTree/SkillTree', 'SkillTable', id);
+  const result = [];
+  for (const node of table.skills || []) {
+    const nodeData = loadJson(dataDir, 'SkillTree/SkillTreeNode', 'SkillTreeNode', node.treeNodeId.guid);
+    const skillId = nodeData.skillId?.guid;
+    const skill = loadJson(dataDir, 'SkillTree/Skill', 'SkillRecord', skillId);
+    const rankGuid = skill.skillRanksIds?.[0]?.guid;
+    let rank = loadJson(dataDir, 'SkillTree/SkillRank', 'SkillRank', rankGuid);
+    if (Object.keys(rank).length === 0) rank = loadJson(dataDir, 'SkillTree/SkillRank', 'SkillRankRecord', rankGuid);
+    const abilityGuid = rank.abilityIdId?.guid;
+    const effectGuid = rank.effectIdId?.guid;
+    let type = 'passive';
+    let name = rank.name;
+    let description = extractLastQuotedValue(rank.tooltipText);
+    let icon = rank.tooltipIcon?.replace('/Game/UI', '/cdn').split('.')[0] + '.png';
+    let cooldown = null;
+    let manaCost = null;
+    if (abilityGuid && abilityGuid !== '0') {
+      type = 'skill';
+      const ability = loadJson(dataDir, 'Abilities/AoCAbility', 'AoCAbility', abilityGuid);
+      if (Object.keys(ability).length === 0) {
+        // try Record prefix
+        ability = loadJson(dataDir, 'Abilities/AoCAbility', 'AoCAbilityRecord', abilityGuid);
+      }
+      if (ability && Object.keys(ability).length) {
+        name = extractLastQuotedValue(ability.abilityName) || name;
+        description = formatDescription(ability.abilityDescription, ability, dataDir);
+        icon = ability.abilityIcon ? ability.abilityIcon.replace('/Game/UI', '/cdn').split('.')[0] + '.png' : icon;
+        const cd = parseFloat(ability.cooldown?.expression);
+        if (!Number.isNaN(cd)) cooldown = cd;
+        manaCost = parseManaCost(ability, dataDir);
+      }
+    } else if (effectGuid && effectGuid !== '0') {
+      type = 'passive';
+      const effect = loadJson(dataDir, 'Effects/Effect', 'Effect', effectGuid);
+      if (Object.keys(effect).length) {
+        name = extractLastQuotedValue(effect.effectName) || name;
+        description = extractLastQuotedValue(effect.effectDescription);
+        icon = effect.effectIcon ? effect.effectIcon.replace('/Game/UI', '/cdn').split('.')[0] + '.png' : icon;
+      }
+    }
+    const maxRank = rank.skillCost?.skillPointCosts?.[0]?.quantity || 1;
+    result.push({
+      id: rank.name,
+      type,
+      cooldown,
+      manaCost,
+      imageUrl: icon,
+      name,
+      description,
+      maxRank,
+      position: { row: node.y, col: node.x },
+      requirements: {
+        pointsSpent: nodeData.pointRequirement,
+        level: nodeData.levelRequirement,
+        prerequisites: (nodeData.skillsRequired || []).map(r => r.skillRequirementId?.name).filter(Boolean)
+      }
+    });
+  }
+  return result;
+}
+
+export { parseSkillTable };
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url) && process.argv.length >= 4) {
+  const tableId = process.argv[2];
+  const baseDir = process.argv[3];
+  const data = parseSkillTable(tableId, baseDir);
+  console.log(JSON.stringify(data, null, 2));
+}


### PR DESCRIPTION
## Summary
- add more robust status name cleaning
- compute lingering tick durations and min/max damage
- convert special markup in ability descriptions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node src/tools/parse-skill-table.js 107813788866168 src/files/VAOC-CL-368574/AOC/Content/DesignData/Data > /tmp/fighter_after.json`
- `node src/tools/parse-skill-table.js 6064631012607131665 src/files/VAOC-CL-368574/AOC/Content/DesignData/Data > /tmp/weapon_after.json`
- `node src/tools/parse-skill-table.js 6064629885900499588 src/files/VAOC-CL-368574/AOC/Content/DesignData/Data > /tmp/bard_after.json`


------
https://chatgpt.com/codex/tasks/task_e_688b08cd972c832286a6097e289d5668