### PR TITLE
Improve set bonus parsing

### DIFF
--- a/src/processor/set-bonus.js
+++ b/src/processor/set-bonus.js
@@ -5,7 +5,13 @@
 import fs from "fs";
 import path from "path";
 import { saveSetBonusToDatabase } from "../db/operations.js";
-import { extractLastQuotedValue, getJson, parseValueExpression } from "../utils.js";
+import {
+  extractLastQuotedValue,
+  getJson,
+  parseValueExpression,
+  extractDescription,
+  extractCoefficient,
+} from "../utils.js";
 
 /**
  * Processes a single JSON file containing set bonus data
@@ -88,17 +94,22 @@ async function processSetBonusFile(filePath, statIdToName, dataDir) {
 
             const statId = modData.statRefId?.guid;
             const statName = statIdToName[statId] || "";
-            const value = parseValueExpression(
+            const parsed = parseValueExpression(
               modData.value?.expression || "",
               modData.valueInputTerms || [],
               statIdToName,
               dataDir
             );
+            const numericValue = extractCoefficient(parsed);
+            const description = extractDescription(
+              effectData.effectDescription || ""
+            ).join(" \n");
 
             const effectObj = {
               ...eff.effect,
               name: statName,
-              value,
+              value: numericValue,
+              description,
             };
 
             processedObject.effectBonuses.push({

--- a/src/utils.js
+++ b/src/utils.js
@@ -385,6 +385,33 @@ function parseValueExpression(
 }
 
 /**
+ * Extracts a numeric coefficient from expressions like "Ceil(0.15*Strength)".
+ * Returns the original expression if no coefficient is found.
+ * @param {string} expression - Expression to parse
+ * @returns {string} Parsed numeric value or original expression
+ */
+function extractCoefficient(expression) {
+  if (!expression) return "";
+  let expr = expression.trim();
+  if (expr.startsWith("Ceil(") && expr.endsWith(")")) {
+    expr = expr.slice(5, -1);
+  } else if (expr.startsWith("Floor(") && expr.endsWith(")")) {
+    expr = expr.slice(6, -1);
+  }
+
+  const numOnly = /^-?\d*\.?\d+$/;
+  if (numOnly.test(expr)) return expr;
+
+  let match = expr.match(/([-+]?\d*\.?\d+)\s*[*x]\s*[A-Za-z_]+/);
+  if (match) return match[1];
+
+  match = expr.match(/[A-Za-z_]+\s*[*x]\s*([-+]?\d*\.?\d+)/);
+  if (match) return match[1];
+
+  return expression;
+}
+
+/**
  * Formats a given number of seconds into a human-readable time string
  * @param {string} seconds - Number of seconds
  * @returns {string} A string representing the time in seconds, minutes, or hours
@@ -418,4 +445,5 @@ export {
   extractExpressionId,
   parseValueExpression,
   formatTime,
+  extractCoefficient,
 };


### PR DESCRIPTION
## Summary
- add numeric coefficient extractor
- include effect descriptions and numeric values when parsing set bonuses

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d29ed02748322a2535b91b96fa7f5