### PR TITLE
feat: import status effects

### DIFF
--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -844,6 +844,41 @@ async function batchSaveSkillTableToDatabase(entries) {
   }
 }
 
+async function batchSaveStatusEffectsToDatabase(entries) {
+  if (!entries || entries.length === 0) {
+    return;
+  }
+  const client = await pool.getConnection();
+  try {
+    await ensureLastModifiedColumn(client, 'DatabaseStatusEffects');
+    await client.query('BEGIN');
+    const query = `
+      INSERT INTO \`DatabaseStatusEffects\` (effectName, effectDescription, effectIcon)
+      VALUES (?, ?, ?)
+      ON DUPLICATE KEY UPDATE
+        effectDescription = VALUES(effectDescription),
+        effectIcon = VALUES(effectIcon),
+        lastModified = CURRENT_TIMESTAMP
+    `;
+    const batchSize = 100;
+    for (let i = 0; i < entries.length; i += batchSize) {
+      const batch = entries.slice(i, i + batchSize);
+      const promises = batch.map((e) => {
+        const values = [e.effectName, e.effectDescription, e.effectIcon];
+        return client.execute(query, values);
+      });
+      await Promise.all(promises);
+    }
+    await client.query('COMMIT');
+    console.log(`Successfully saved ${entries.length} status effects in batch operation`);
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`Error in batch save operation: ${error.message}`);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
 export {
   saveItemRecipeToDatabase,
   saveStatToDatabase,
@@ -859,4 +894,5 @@ export {
   saveLootInfoToDatabase,
   savePlayerStatsToDatabase,
   batchSaveSkillTableToDatabase,
+  batchSaveStatusEffectsToDatabase,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ import { processEnchantmentLevelFiles } from "./processor/enchantment-level.js";
 import { processRecipeFiles } from "./processor/recipe.js";
 import { processLootFiles } from "./processor/loot.js";
 import { processSkillTables } from "./processor/skill-table.js";
+import { processStatusEffects } from "./processor/status-effects.js";
 import { processPlayerStats } from "./processor/player-stats.js";
 import {
   directoryStats,
@@ -169,6 +170,10 @@ async function main() {
     console.log("\nProcessing skill tables...");
     const skillsProcessed = await processSkillTables(directoryData);
     console.log(`Skill tables processing complete: ${skillsProcessed} entries saved`);
+
+    console.log("\nProcessing status effect files...");
+    const effectsProcessed = await processStatusEffects(directoryData, statIdToName);
+    console.log(`Status effects processing complete: ${effectsProcessed} entries saved`);
 
     console.log("\nAll processing complete. Closing connections...");
   } catch (error) {

--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import path from 'path';
+import { batchSaveStatusEffectsToDatabase } from '../db/operations.js';
+import { getJson, extractDescription, extractLastQuotedValue, parseValueExpression, formatTime } from '../utils.js';
+
+function evaluateExpression(expr) {
+  if (!expr) return NaN;
+  const sanitized = expr.replace(/[^0-9+\-*/().\s]/g, '');
+  if (!sanitized) return NaN;
+  try {
+    // eslint-disable-next-line no-new-func
+    return Function(`return (${sanitized});`)();
+  } catch {
+    return NaN;
+  }
+}
+
+function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
+  let result = text;
+
+  // Duration placeholder
+  if (result.includes('$duration$')) {
+    let durationExpr = parseValueExpression(
+      effectData.effectDuration?.expression || '',
+      [],
+      statIdToName,
+      dataDir
+    );
+    const durationVal = evaluateExpression(durationExpr);
+    const durationStr = !isNaN(durationVal)
+      ? formatTime(durationVal)
+      : durationExpr;
+    result = result.replace(/\$duration\$/g, durationStr);
+  }
+
+  // Statmod placeholders
+  const statMods = effectData.statModsIds || [];
+  result = result.replace(/\$statmod(\d+)\.(by%|nostat)\$/gi, (m, idx, type) => {
+    const index = parseInt(idx, 10);
+    const ref = statMods[index];
+    if (!ref) return m;
+    let mod = getJson(dataDir, '/Effects/StatMod', `StatMod_${ref.guid}.json`);
+    if (!mod || Object.keys(mod).length === 0) {
+      mod = getJson(dataDir, '/Effects/StatMod', `StatModRecord_${ref.guid}.json`);
+    }
+    if (!mod || Object.keys(mod).length === 0) return m;
+    let expr = parseValueExpression(
+      mod.value?.expression || '',
+      mod.valueInputTerms,
+      statIdToName,
+      dataDir
+    );
+    const val = evaluateExpression(expr);
+    const statName = statIdToName[mod.statRefId?.guid] || '';
+    if (type.toLowerCase() === 'by%') {
+      if (!isNaN(val)) {
+        const num = (val * 100).toFixed(0);
+        return `${num}%${statName ? ' ' + statName : ''}`.trim();
+      }
+      return `${expr}${statName ? ' ' + statName : ''}`.trim();
+    }
+    if (!isNaN(val)) return String(val);
+    return expr;
+  });
+
+  return result;
+}
+
+async function processStatusEffects(directoryData, statIdToName) {
+  const dir = path.join(directoryData, 'Effects/Effect');
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  const entries = [];
+
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (
+      (data.effectCategory !== 'EFFECT_Debuff' && data.effectCategory !== 'EFFECT_Buff') ||
+      !data.effectIcon ||
+      data.effectIcon === 'None'
+    ) {
+      continue;
+    }
+
+    const name = extractLastQuotedValue(data.effectName) || data.effectName || '';
+    const descArray = extractDescription(data.effectDescription);
+    let description = descArray.join(' ').trim();
+    if (description) {
+      description = resolvePlaceholders(description, data, directoryData, statIdToName);
+    }
+
+    entries.push({
+      effectName: name,
+      effectDescription: description,
+      effectIcon: data.effectIcon,
+    });
+  }
+
+  await batchSaveStatusEffectsToDatabase(entries);
+  console.log(`Successfully processed ${entries.length} status effects`);
+  return entries.length;
+}
+
+export { processStatusEffects };


### PR DESCRIPTION
## Summary
- import status effects and parse placeholders
- batch save status effects to database
- run parser to load status effect data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d85a9f0948322911d01323f7da76a