### PR TITLE
Ensure DatabaseStatusEffects table is recreated when missing

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -279,6 +279,16 @@ export async function initDatabase() {
     await ensureLastModifiedColumn(conn, 'DatabaseSkillTable');
     await ensureColumnExists(conn, 'DatabaseSkillTable', 'manaCost', 'JSON');
 
+    await conn.query(`
+      CREATE TABLE IF NOT EXISTS DatabaseStatusEffects (
+        effectName VARCHAR(255) PRIMARY KEY,
+        effectDescription TEXT,
+        effectIcon TEXT,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      )
+    `);
+    await ensureLastModifiedColumn(conn, 'DatabaseStatusEffects');
+
     console.log("Database tables initialized");
   } finally {
     conn.release();

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -850,6 +850,14 @@ async function batchSaveStatusEffectsToDatabase(entries) {
   }
   const client = await pool.getConnection();
   try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS \`DatabaseStatusEffects\` (
+        effectName VARCHAR(255) PRIMARY KEY,
+        effectDescription TEXT,
+        effectIcon TEXT,
+        lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      )
+    `);
     await ensureLastModifiedColumn(client, 'DatabaseStatusEffects');
     await client.query('BEGIN');
     const query = `


### PR DESCRIPTION
## Summary
- create `DatabaseStatusEffects` table during DB init
- create `DatabaseStatusEffects` table on batch save if missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d9291b5348322ae02a7faf366ead6