### PR TITLE
Fix status effect parsing and persist categories

### DIFF
--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -855,24 +855,27 @@ async function batchSaveStatusEffectsToDatabase(entries) {
         effectName VARCHAR(255) PRIMARY KEY,
         effectDescription TEXT,
         effectIcon TEXT,
+        effectCategory VARCHAR(255),
         lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
     await ensureLastModifiedColumn(client, 'DatabaseStatusEffects');
+    await ensureColumn(client, 'DatabaseStatusEffects', 'effectCategory', 'VARCHAR(255)');
     await client.query('BEGIN');
     const query = `
-      INSERT INTO \`DatabaseStatusEffects\` (effectName, effectDescription, effectIcon)
-      VALUES (?, ?, ?)
+      INSERT INTO \`DatabaseStatusEffects\` (effectName, effectDescription, effectIcon, effectCategory)
+      VALUES (?, ?, ?, ?)
       ON DUPLICATE KEY UPDATE
         effectDescription = VALUES(effectDescription),
         effectIcon = VALUES(effectIcon),
+        effectCategory = VALUES(effectCategory),
         lastModified = CURRENT_TIMESTAMP
     `;
     const batchSize = 100;
     for (let i = 0; i < entries.length; i += batchSize) {
       const batch = entries.slice(i, i + batchSize);
       const promises = batch.map((e) => {
-        const values = [e.effectName, e.effectDescription, e.effectIcon];
+        const values = [e.effectName, e.effectDescription, e.effectIcon, e.effectCategory];
         return client.execute(query, values);
       });
       await Promise.all(promises);

--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -35,7 +35,7 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
 
   // Statmod placeholders
   const statMods = effectData.statModsIds || [];
-  result = result.replace(/\$statmod(\d+)\.(by%|nostat)\$/gi, (m, idx, type) => {
+  result = result.replace(/\$statmod(\d+)\.(by%|nostat|onlystat)\$/gi, (m, idx, type) => {
     const index = parseInt(idx, 10);
     const ref = statMods[index];
     if (!ref) return m;
@@ -44,6 +44,10 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
       mod = getJson(dataDir, '/Effects/StatMod', `StatModRecord_${ref.guid}.json`);
     }
     if (!mod || Object.keys(mod).length === 0) return m;
+    const statName = statIdToName[mod.statRefId?.guid] || '';
+    if (type.toLowerCase() === 'onlystat') {
+      return statName || m;
+    }
     let expr = parseValueExpression(
       mod.value?.expression || '',
       mod.valueInputTerms,
@@ -51,7 +55,6 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
       dataDir
     );
     const val = evaluateExpression(expr);
-    const statName = statIdToName[mod.statRefId?.guid] || '';
     if (type.toLowerCase() === 'by%') {
       if (!isNaN(val)) {
         const num = (val * 100).toFixed(0);
@@ -62,6 +65,58 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
     if (!isNaN(val)) return String(val);
     return expr;
   });
+
+  // Tick statmod placeholders (e.g., $tick0:statmod0.onlystat$)
+  result = result.replace(
+    /\$tick(\d+):statmod(\d+)\.(by%|nostat|onlystat)\$/gi,
+    (m, tickIdx, modIdx, type) => {
+      const tIdx = parseInt(tickIdx, 10);
+      const mIdx = parseInt(modIdx, 10);
+      const hitRef = (effectData.tickHitsIds || [])[tIdx];
+      if (!hitRef) return m;
+      const hit = getJson(
+        dataDir,
+        '/Abilities/AbilityHit',
+        `AbilityHit_${hitRef.guid}.json`
+      );
+      const mods = hit.statModsIds || [];
+      const ref = mods[mIdx];
+      if (!ref) return m;
+      let mod = getJson(dataDir, '/Effects/StatMod', `StatMod_${ref.guid}.json`);
+      if (!mod || Object.keys(mod).length === 0) {
+        mod = getJson(dataDir, '/Effects/StatMod', `StatModRecord_${ref.guid}.json`);
+      }
+      if (!mod || Object.keys(mod).length === 0) return m;
+      const statName = statIdToName[mod.statRefId?.guid] || '';
+      if (type.toLowerCase() === 'onlystat') {
+        return statName || m;
+      }
+      let expr = parseValueExpression(
+        mod.value?.expression || '',
+        mod.valueInputTerms,
+        statIdToName,
+        dataDir
+      );
+      const val = evaluateExpression(expr);
+      if (type.toLowerCase() === 'by%') {
+        if (!isNaN(val)) {
+          const num = (val * 100).toFixed(0);
+          return `${num}%${statName ? ' ' + statName : ''}`.trim();
+        }
+        return `${expr}${statName ? ' ' + statName : ''}`.trim();
+      }
+      if (!isNaN(val)) return String(val);
+      return expr;
+    }
+  );
+
+  // Tick timer placeholder
+  if (result.includes('$tick$')) {
+    const tickTime = effectData.tickTimer;
+    if (typeof tickTime === 'number' && tickTime > 0) {
+      result = result.replace(/\$tick\$/g, `${tickTime} seconds`);
+    }
+  }
 
   return result;
 }
@@ -93,6 +148,7 @@ async function processStatusEffects(directoryData, statIdToName) {
       effectName: name,
       effectDescription: description,
       effectIcon: data.effectIcon,
+      effectCategory: data.effectCategory,
     });
   }
 


### PR DESCRIPTION
## Summary
- handle $statmod.onlystat$ and tick statmod placeholders when parsing status effect descriptions
- save effect category in status effect records and database table

## Testing
- `node -e "import('./src/processor/status-effects.js').then(()=>console.log('loaded'))"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e2556db108322b744636a2378f574