### PR TITLE
Include SkillTableRecord files in skill table processing

### DIFF
--- a/src/processor/skill-table.js
+++ b/src/processor/skill-table.js
@@ -8,7 +8,13 @@ const CLASS_NAMES = ['Fighter','Tank','Cleric','Bard','Mage','Ranger','Rogue','S
 
 async function processSkillTables(directoryData) {
   const dir = path.join(directoryData, 'SkillTree/SkillTree');
-  const files = fs.readdirSync(dir).filter(f => f.startsWith('SkillTable_') && f.endsWith('.json'));
+  const files = fs
+    .readdirSync(dir)
+    .filter(
+      (f) =>
+        (f.startsWith('SkillTable_') || f.startsWith('SkillTableRecord_')) &&
+        f.endsWith('.json')
+    );
   const allSkills = [];
   for (const file of files) {
     const filePath = path.join(dir, file);
@@ -17,7 +23,7 @@ async function processSkillTables(directoryData) {
     if (!tableName) continue;
     if (!CLASS_NAMES.includes(tableName) && !tableName.startsWith('Weapon_')) continue;
     if (tableName.includes('_Stage')) continue;
-    const match = file.match(/SkillTable_(\d+)/);
+    const match = file.match(/SkillTable(?:Record)?_(\d+)/);
     if (!match) continue;
     const tableId = match[1];
     const skills = parseSkillTable(tableId, directoryData);


### PR DESCRIPTION
## Summary
- support `SkillTableRecord_*.json` files in the skill table processor so the Ranger skill tree is parsed

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "import('./src/tools/parse-skill-table.js').then(m=>{const data=m.parseSkillTable('108850029942393','src/files/vAOC-CL-375287/AOC/Content/DesignData/Data'); console.log('length',data.length);}).catch(console.error)"`


------
https://chatgpt.com/codex/tasks/task_e_688f0a727c788322bbde3c1d5ac2bd0f