### PR TITLE
feat: enrich effects and clean ability text

### DIFF
--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -856,26 +856,46 @@ async function batchSaveStatusEffectsToDatabase(entries) {
         effectDescription TEXT,
         effectIcon TEXT,
         effectCategory VARCHAR(255),
+        effectElement VARCHAR(255),
+        effectDuration FLOAT,
+        effectDispellable TINYINT(1),
         lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
     await ensureLastModifiedColumn(client, 'DatabaseStatusEffects');
     await ensureColumn(client, 'DatabaseStatusEffects', 'effectCategory', 'VARCHAR(255)');
+    await ensureColumn(client, 'DatabaseStatusEffects', 'effectElement', 'VARCHAR(255)');
+    await ensureColumn(client, 'DatabaseStatusEffects', 'effectDuration', 'FLOAT');
+    await ensureColumn(client, 'DatabaseStatusEffects', 'effectDispellable', 'TINYINT(1)');
     await client.query('BEGIN');
     const query = `
-      INSERT INTO \`DatabaseStatusEffects\` (effectName, effectDescription, effectIcon, effectCategory)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO \`DatabaseStatusEffects\` (
+        effectName, effectDescription, effectIcon,
+        effectCategory, effectElement, effectDuration, effectDispellable
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       ON DUPLICATE KEY UPDATE
         effectDescription = VALUES(effectDescription),
         effectIcon = VALUES(effectIcon),
         effectCategory = VALUES(effectCategory),
+        effectElement = VALUES(effectElement),
+        effectDuration = VALUES(effectDuration),
+        effectDispellable = VALUES(effectDispellable),
         lastModified = CURRENT_TIMESTAMP
     `;
     const batchSize = 100;
     for (let i = 0; i < entries.length; i += batchSize) {
       const batch = entries.slice(i, i + batchSize);
       const promises = batch.map((e) => {
-        const values = [e.effectName, e.effectDescription, e.effectIcon, e.effectCategory];
+        const values = [
+          e.effectName,
+          e.effectDescription,
+          e.effectIcon,
+          e.effectCategory,
+          e.effectElement,
+          e.effectDuration,
+          e.effectDispellable,
+        ];
         return client.execute(query, values);
       });
       await Promise.all(promises);

--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -1,7 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { batchSaveStatusEffectsToDatabase } from '../db/operations.js';
-import { getJson, extractDescription, extractLastQuotedValue, parseValueExpression, formatTime } from '../utils.js';
+import {
+  getJson,
+  extractDescription,
+  extractLastQuotedValue,
+  parseValueExpression,
+  formatTime,
+} from '../utils.js';
 
 function evaluateExpression(expr) {
   if (!expr) return NaN;
@@ -141,14 +147,39 @@ async function processStatusEffects(directoryData, statIdToName) {
     const descArray = extractDescription(data.effectDescription);
     let description = descArray.join(' ').trim();
     if (description) {
-      description = resolvePlaceholders(description, data, directoryData, statIdToName);
+      description = resolvePlaceholders(
+        description,
+        data,
+        directoryData,
+        statIdToName
+      );
     }
+
+    let effectDuration = null;
+    if (data.effectDuration?.expression) {
+      const durExpr = parseValueExpression(
+        data.effectDuration.expression,
+        [],
+        statIdToName,
+        directoryData
+      );
+      const durVal = evaluateExpression(durExpr);
+      effectDuration = !isNaN(durVal) ? durVal : null;
+    }
+
+    const effectElement = (data.effectTags || [])
+      .map((t) => t.tagName)
+      .find((t) => t.startsWith('Element.'))
+      ?.split('.').pop();
 
     entries.push({
       effectName: name,
       effectDescription: description,
       effectIcon: data.effectIcon,
       effectCategory: data.effectCategory,
+      effectElement: effectElement || null,
+      effectDuration,
+      effectDispellable: data.bDispellable ?? null,
     });
   }
 

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -1,7 +1,23 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { extractLastQuotedValue } from '../utils.js';
+import {
+  extractLastQuotedValue,
+  parseValueExpression,
+} from '../utils.js';
+import { statIdToName } from '../config.js';
+
+function evaluateExpression(expr) {
+  if (!expr) return NaN;
+  const sanitized = expr.replace(/[^0-9+\-*/().\s]/g, '');
+  if (!sanitized) return NaN;
+  try {
+    // eslint-disable-next-line no-new-func
+    return Function(`return (${sanitized});`)();
+  } catch {
+    return NaN;
+  }
+}
 
 function findJsonFile(dir, prefix, id) {
   const direct = path.join(dir, `${prefix}_${id}.json`);
@@ -251,8 +267,67 @@ function resolveSkillName(skillToken, dataDir) {
   return formatEffectName(skillToken);
 }
 
+function resolveStatModPlaceholders(text, ability, dataDir) {
+  if (!text) return text;
+
+  const replaceMod = (mod, type) => {
+    if (!mod) return '';
+    const statName = statIdToName[mod.statRefId?.guid] || '';
+    let expr = parseValueExpression(
+      mod.value?.expression || '',
+      mod.valueInputTerms,
+      statIdToName,
+      dataDir
+    );
+    const val = evaluateExpression(expr);
+    const t = type.toLowerCase();
+    if (t.includes('onlystat')) return statName || '';
+    if (t.includes('by%') || t.startsWith('f%')) {
+      if (!isNaN(val)) {
+        return `${(val * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
+      }
+      return `${expr}${statName ? ' ' + statName : ''}`.trim();
+    }
+    if (!isNaN(val)) {
+      return `${val}${statName ? ' ' + statName : ''}`.trim();
+    }
+    return `${expr}${statName ? ' ' + statName : ''}`.trim();
+  };
+
+  const statMods = ability.statModsIds || [];
+  text = text.replace(/\$statmod(\d+)\.([^$]+)\$/gi, (m, idx, type) => {
+    const ref = statMods[parseInt(idx, 10)];
+    if (!ref) return m;
+    let mod = loadJson(dataDir, 'Effects/StatMod', 'StatMod', ref.guid);
+    if (!mod || Object.keys(mod).length === 0) {
+      mod = loadJson(dataDir, 'Effects/StatMod', 'StatModRecord', ref.guid);
+    }
+    if (!mod || Object.keys(mod).length === 0) return m;
+    return replaceMod(mod, type);
+  });
+
+  text = text.replace(/\$hit(\d+):statmod(\d+)\.([^$]+)\$/gi, (m, hitIdx, modIdx, type) => {
+    const hitRef = ability.hitsIds?.[hitIdx];
+    if (!hitRef) return m;
+    const hit = loadAbilityHit(hitRef.guid, dataDir);
+    if (!hit) return m;
+    const ref = (hit.statModsIds || [])[parseInt(modIdx, 10)];
+    if (!ref) return m;
+    let mod = loadJson(dataDir, 'Effects/StatMod', 'StatMod', ref.guid);
+    if (!mod || Object.keys(mod).length === 0) {
+      mod = loadJson(dataDir, 'Effects/StatMod', 'StatModRecord', ref.guid);
+    }
+    if (!mod || Object.keys(mod).length === 0) return m;
+    return replaceMod(mod, type);
+  });
+
+  return text;
+}
+
 function formatDescription(desc, ability, dataDir) {
   let text = extractLastQuotedValue(desc);
+  text = resolveStatModPlaceholders(text, ability, dataDir);
+
   if (ability.hitsIds && ability.hitsIds['1']) {
     const dmg = parseDamage(ability.hitsIds['1'].guid, dataDir);
     if (dmg && dmg.percent) {
@@ -351,13 +426,17 @@ function formatDescription(desc, ability, dataDir) {
     return `${name}: ${clean}`;
   });
 
+  text = text.replace(/: ([^:<>]+:[^:<>]+):<>/g, (_, name) => `: [${name}]<br>`);
+  text = text.replace(/([A-Za-z][A-Za-z' ]+?)<>/g, (_, name) => `[${name.trim()}]`);
+  text = text.replace(/<>/g, '');
+  text = text.replace(/\r\n|\n/g, '<br>');
+
   text = text.replace(/\$charges\$/g, () => {
     const val = parseFloat(ability.cooldownCharges?.expression);
     return Number.isNaN(val) ? '0' : String(val);
   });
 
   text = text.replace(/rnrn/g, '  ');
-  text = text.replace(/\r\n|\n/g, ' ');
   text = text.replace(/<img[^>]*id=\"([^\"]+)\"[^>]*>/g, (_, id) => `[${formatEffectName(id)}]`);
   text = text.replace(/\((\s*\[[^\]]+\]\s*)+\)/g, (m) => m.slice(1, -1));
   text = text.replace(/Healing Damage/gi, 'Healing');


### PR DESCRIPTION
## Summary
- add element, duration and dispellable info to status effects
- store new effect columns in database
- clean ability descriptions by resolving stat mods and formatting names/line breaks

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6891a3d3ee088322bdcd98adf2e3188f