### PR TITLE
Add range and angle to skill table entries

### DIFF
--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -790,13 +790,15 @@ async function batchSaveSkillTableToDatabase(entries) {
   const client = await pool.getConnection();
   try {
     await ensureLastModifiedColumn(client, 'DatabaseSkillTable');
+    await ensureColumn(client, 'DatabaseSkillTable', 'range', 'FLOAT');
+    await ensureColumn(client, 'DatabaseSkillTable', 'angle', 'FLOAT');
     await client.query('BEGIN');
     const query = `
       INSERT INTO \`DatabaseSkillTable\` (
         id, tableId, tableName, name, description, type, cooldown, manaCost, maxRank,
-        imageUrl, position, requirements
+        imageUrl, position, requirements, \`range\`, angle
       ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
         tableId = VALUES(tableId),
         tableName = VALUES(tableName),
@@ -809,6 +811,8 @@ async function batchSaveSkillTableToDatabase(entries) {
         imageUrl = VALUES(imageUrl),
         position = VALUES(position),
         requirements = VALUES(requirements),
+        \`range\` = VALUES(\`range\`),
+        angle = VALUES(angle),
         lastModified = CURRENT_TIMESTAMP
     `;
     const batchSize = 100;
@@ -827,7 +831,9 @@ async function batchSaveSkillTableToDatabase(entries) {
           e.maxRank ?? null,
           e.imageUrl ?? null,
           JSON.stringify(e.position || {}),
-          JSON.stringify(e.requirements || {})
+          JSON.stringify(e.requirements || {}),
+          e.range ?? null,
+          e.angle ?? null
         ];
         return client.execute(query, values);
       });

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -497,6 +497,8 @@ function parseSkillTable(id, dataDir) {
         rank.tooltipIcon?.replace('/Game/UI', '/cdn').split('.')[0] + '.png';
       let cooldown = null;
       let manaCost = null;
+      let range = null;
+      let angle = null;
       if (abilityGuid && abilityGuid !== '0') {
         type = 'skill';
         const ability = loadJson(
@@ -528,6 +530,12 @@ function parseSkillTable(id, dataDir) {
           const cd = parseFloat(ability.cooldown?.expression);
           if (!Number.isNaN(cd)) cooldown = cd;
           manaCost = parseManaCost(ability, dataDir);
+          if (typeof ability.validDistance === 'number') {
+            range = ability.validDistance / 100;
+          }
+          if (typeof ability.validAngle === 'number') {
+            angle = ability.validAngle;
+          }
         }
       } else if (effectGuid && effectGuid !== '0') {
         type = 'passive';
@@ -551,6 +559,8 @@ function parseSkillTable(id, dataDir) {
         type,
         cooldown,
         manaCost,
+        range,
+        angle,
         imageUrl: icon,
         name,
         description,


### PR DESCRIPTION
## Summary
- include ability range and angle in parsed skill table records
- persist new range and angle fields to the skill table database

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891a6d276f483229281610e9a32c223