### PR TITLE
Use ability description fallback

### DIFF
--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -892,6 +892,13 @@ function parseSkillTable(id, dataDir) {
             ability,
             dataDir
           );
+          if (!description) {
+            description = formatDescription(
+              ability.abilityDescription,
+              ability,
+              dataDir
+            );
+          }
           icon = ability.abilityIcon
             ? ability.abilityIcon.split('.')[0] +
               '.webp'


### PR DESCRIPTION
## Summary
- parse ability descriptions from AoCAbility when skill rank tooltip is empty

## Testing
- `npm test`
- `node src/tools/parse-skill-table.js 6064630422842835238 src/files/vAOC-CL-375287/AOC/Content/DesignData/Data | rg -n "Rogue_Poison_Corrosive" -A60`


------
https://chatgpt.com/codex/tasks/task_e_689996e460788322906719cb507b495a