### PR TITLE
Wrap status effects in ability descriptions

### DIFF
--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -82,6 +82,49 @@ function formatEffectName(name) {
   return out;
 }
 
+const statusEffectCache = new Map();
+
+function getStatusEffectNames(dataDir) {
+  if (statusEffectCache.has(dataDir)) return statusEffectCache.get(dataDir);
+  const dir = path.join(dataDir, 'Effects/Effect');
+  let names = [];
+  if (fs.existsSync(dir)) {
+    names = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => {
+        try {
+          const data = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+          const raw = extractLastQuotedValue(data.effectName) || data.effectName;
+          return formatEffectName(raw);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  }
+  statusEffectCache.set(dataDir, names);
+  return names;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function wrapStatusEffects(text, dataDir) {
+  const names = getStatusEffectNames(dataDir);
+  for (const n of names) {
+    const regex = new RegExp(`\\b${escapeRegExp(n)}\\b`, 'g');
+    text = text.replace(regex, (match, offset, str) => {
+      const before = str[offset - 1];
+      const after = str[offset + match.length];
+      if (before === '[' && after === ']') return match;
+      return `[${match}]`;
+    });
+  }
+  return text;
+}
+
 function parseManaCost(ability, dataDir) {
   let costsArray = ability.statCosts || [];
   if ((!costsArray || costsArray.length === 0) && Array.isArray(ability.costs)) {
@@ -796,6 +839,7 @@ function formatDescription(desc, ability, dataDir) {
   text = text.replace(/\$flavor:([^$]+)\$/gi, (_, w) => `<i>${w.replace(/^"|"$/g, '')}</i>`);
   text = text.replace(/\\'/g, "'");
   text = text.replace(/Healing Damage/gi, 'Healing');
+  text = wrapStatusEffects(text, dataDir);
   text = text.replace(/\s+/g, ' ').trim();
   return text;
 }


### PR DESCRIPTION
## Summary
- load all status effect names and cache them
- auto-wrap status effect names in skill descriptions

## Testing
- `npm test` *(fails: no test specified)*
- `node src/tools/parse-skill-table.js 107813788866168 src/files/vAOC-CL-375287/AOC/Content/DesignData/Data > /tmp/output_after.json`


------
https://chatgpt.com/codex/tasks/task_e_689a5dd4c2048322a9439aa0647c54c9