### PR TITLE
Wrap status effects in ability descriptions

### DIFF
--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -82,6 +82,52 @@ function formatEffectName(name) {
   return out;
 }
 
+const statusEffectCache = new Map();
+
+function getStatusEffectNames(dataDir) {
+  if (statusEffectCache.has(dataDir)) return statusEffectCache.get(dataDir);
+  const dir = path.join(dataDir, 'Effects/Effect');
+  let names = [];
+  if (fs.existsSync(dir)) {
+    names = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => {
+        try {
+          const data = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+          const raw = extractLastQuotedValue(data.effectName) || data.effectName;
+          return formatEffectName(raw);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  }
+  statusEffectCache.set(dataDir, names);
+  return names;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function wrapStatusEffects(text, dataDir) {
+  const names = getStatusEffectNames(dataDir).sort((a, b) => b.length - a.length);
+  const isWrapped = (str, start, end) => {
+    const open = str.lastIndexOf('[', start);
+    const close = str.indexOf(']', end);
+    return open !== -1 && close !== -1 && open < start && close >= end;
+  };
+  for (const n of names) {
+    const regex = new RegExp(`\\b${escapeRegExp(n)}\\b`, 'g');
+    text = text.replace(regex, (match, offset, str) => {
+      if (isWrapped(str, offset, offset + match.length)) return match;
+      return `[${match}]`;
+    });
+  }
+  return text;
+}
+
 function parseManaCost(ability, dataDir) {
   let costsArray = ability.statCosts || [];
   if ((!costsArray || costsArray.length === 0) && Array.isArray(ability.costs)) {
@@ -628,6 +674,41 @@ function formatDescription(desc, ability, dataDir) {
     return `${dur} second${dur === 1 ? '' : 's'}`;
   });
 
+  text = text.replace(/\$linger(\d+):init(\d+)\$/g, (m, lIdx, hIdx) => {
+    const lGuid = ability.lingeringEffectsIds?.[lIdx]?.guid;
+    if (!lGuid) return m;
+    const ling = loadJson(
+      dataDir,
+      'Abilities/LingeringEffect',
+      'LingeringEffect',
+      lGuid
+    );
+    const hitGuid = ling.initialHitsIds?.[hIdx]?.guid;
+    if (!hitGuid) return m;
+    const dmg = parseDamage(hitGuid, dataDir);
+    return dmg && dmg.percent ? `${dmg.percent}% ${dmg.element} Damage` : m;
+  });
+
+  text = text.replace(/\$linger(\d+):init(\d+)\.apply(\d+)(fordur)?\$/g, (m, lIdx, hIdx, aIdx, fordur) => {
+    const lGuid = ability.lingeringEffectsIds?.[lIdx]?.guid;
+    if (!lGuid) return '';
+    const ling = loadJson(
+      dataDir,
+      'Abilities/LingeringEffect',
+      'LingeringEffect',
+      lGuid
+    );
+    const hitGuid = ling.initialHitsIds?.[hIdx]?.guid;
+    if (!hitGuid) return '';
+    const eff = parseApplyEffectName(hitGuid, parseInt(aIdx, 10), dataDir);
+    if (!eff) return '';
+    if (fordur) {
+      const dur = parseApplyEffectDuration(hitGuid, parseInt(aIdx, 10), dataDir);
+      return dur ? `[${eff}] for ${dur}` : `[${eff}]`;
+    }
+    return `[${eff}]`;
+  });
+
   text = text.replace(/\$linger(\d+):linger(\d+)\.minmax\$/g, (m, lIdx, hIdx) => {
     const lGuid = ability.lingeringEffectsIds?.[lIdx]?.guid;
     if (!lGuid) return m;
@@ -776,9 +857,16 @@ function formatDescription(desc, ability, dataDir) {
     return `${name}: ${clean}`;
   });
 
-  text = text.replace(/: ([^:<>]+:[^:<>]+):<>/g, (_, name) => `: [${name}]<br>`);
-  text = text.replace(/([A-Za-z][A-Za-z' ]+?)<>/g, (_, name) => `[${name.trim()}]`);
-  text = text.replace(/<>/g, '');
+  const abilityName = (extractLastQuotedValue(ability.abilityName) || '').toLowerCase();
+  if (abilityName === 'doublestrike') {
+    text = text.replace(/: ([^:<>]+):<>/g, ':<br>$1<br>');
+    text = text.replace(/([^:<>]+):<>/g, '$1<br>');
+    text = text.replace(/([^:<>]+)<>/g, '$1');
+  } else {
+    text = text.replace(/: ([^:<>]+:[^:<>]+):<>/g, (_, name) => `: [${name}]<br>`);
+    text = text.replace(/([A-Za-z][A-Za-z' ]+?)<>/g, (_, name) => `[${name.trim()}]`);
+    text = text.replace(/<>/g, '');
+  }
   text = text.replace(/\r\n|\n/g, '<br>');
   text = text.replace(/rnrn/g, '<br><br>');
   text = text.replace(/(^|\W)rn/g, '$1<br>');
@@ -792,11 +880,30 @@ function formatDescription(desc, ability, dataDir) {
   text = text.replace(/<img[^>]*id=\"([^\"]+)\"[^>]*>/g, (_, id) => `[${formatEffectName(id)}]`);
   text = text.replace(/\((\s*\[[^\]]+\]\s*)+\)/g, (m) => m.slice(1, -1));
   text = text.replace(/<\/?highlight>/gi, '');
-  text = text.replace(/<\/>/g, '');
+  const tagStack = [];
+  text = text.replace(/<Bold>|<bold>|<Flavor>|<flavor>|<\/>/g, (tag) => {
+    const lower = tag.toLowerCase();
+    if (lower === '<bold>') {
+      tagStack.push('bold');
+      return '<bold>';
+    }
+    if (lower === '<flavor>') {
+      tagStack.push('i');
+      return '<i>';
+    }
+    if (tag === '</>') {
+      const last = tagStack.pop();
+      return last ? `</${last}>` : '';
+    }
+    return tag;
+  });
   text = text.replace(/\$flavor:([^$]+)\$/gi, (_, w) => `<i>${w.replace(/^"|"$/g, '')}</i>`);
   text = text.replace(/\\'/g, "'");
   text = text.replace(/Healing Damage/gi, 'Healing');
+  text = wrapStatusEffects(text, dataDir);
   text = text.replace(/\s+/g, ' ').trim();
+  text = text.replace(/(<br>)+$/g, '').trim();
+  if (text && !/[.!?]$/.test(text)) text += '.';
   return text;
 }
 


### PR DESCRIPTION
## Summary
- load all status effect names and cache them
- auto-wrap status effect names in skill descriptions
- parse lingering `init` hits, normalize bold/flavor tags, and special-case Doublestrike lists

## Testing
- `npm test` *(fails: no test specified)*
- `node src/tools/parse-skill-table.js 107813788866168 src/files/vAOC-CL-375287/AOC/Content/DesignData/Data > /tmp/output_after.json`


------
https://chatgpt.com/codex/tasks/task_e_689a5dd4c2048322a9439aa0647c54c9