### PR TITLE
Enhance loot parser with item names, drop rates, and spawn locations

### DIFF
--- a/src/db/config.js
+++ b/src/db/config.js
@@ -238,9 +238,11 @@ export async function initDatabase() {
         levelMax INT,
         difficulty TEXT,
         zone TEXT,
+        worldSpawnLocation TEXT,
         spawnRate INT,
         dropChance DOUBLE,
-        coordinates JSON,
+        zoneCoordinates JSON,
+        worldCoordinates JSON,
       lastModified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       )
     `);
@@ -249,6 +251,9 @@ export async function initDatabase() {
     await conn.query(
       "ALTER TABLE `DatabaseLootInfo` MODIFY COLUMN `id` VARCHAR(512)"
     );
+    await ensureColumnExists(conn, 'DatabaseLootInfo', 'worldSpawnLocation', 'TEXT');
+    await ensureColumnExists(conn, 'DatabaseLootInfo', 'zoneCoordinates', 'JSON');
+    await ensureColumnExists(conn, 'DatabaseLootInfo', 'worldCoordinates', 'JSON');
 
     await conn.query(`
       CREATE TABLE IF NOT EXISTS DatabasePlayerStats (

--- a/src/db/operations.js
+++ b/src/db/operations.js
@@ -716,12 +716,15 @@ async function saveLootInfoToDatabase(loot) {
   const client = await pool.getConnection();
   try {
     await ensureLastModifiedColumn(client, 'DatabaseLootInfo');
+    await ensureColumn(client, 'DatabaseLootInfo', 'worldSpawnLocation', 'TEXT');
+    await ensureColumn(client, 'DatabaseLootInfo', 'zoneCoordinates', 'JSON');
+    await ensureColumn(client, 'DatabaseLootInfo', 'worldCoordinates', 'JSON');
     const query = `
       INSERT INTO \`DatabaseLootInfo\` (
         id, itemId, questName, step, npcName, levelMin, levelMax,
-        difficulty, zone, spawnRate, dropChance, coordinates
+        difficulty, zone, worldSpawnLocation, spawnRate, dropChance, zoneCoordinates, worldCoordinates
       ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       ) ON DUPLICATE KEY UPDATE
         questName = VALUES(questName),
         step = VALUES(step),
@@ -730,9 +733,11 @@ async function saveLootInfoToDatabase(loot) {
         levelMax = VALUES(levelMax),
         difficulty = VALUES(difficulty),
         zone = VALUES(zone),
+        worldSpawnLocation = VALUES(worldSpawnLocation),
         spawnRate = VALUES(spawnRate),
         dropChance = VALUES(dropChance),
-        coordinates = VALUES(coordinates),
+        zoneCoordinates = VALUES(zoneCoordinates),
+        worldCoordinates = VALUES(worldCoordinates),
         lastModified = CURRENT_TIMESTAMP
     `;
     const values = [
@@ -745,9 +750,11 @@ async function saveLootInfoToDatabase(loot) {
       loot.levelMax ?? null,
       loot.difficulty ?? null,
       loot.zone ?? null,
+      loot.worldSpawnLocation ?? null,
       loot.spawnRate ?? null,
       loot.dropChance ?? null,
-      JSON.stringify(loot.coordinates || {})
+      JSON.stringify(loot.zoneCoordinates || {}),
+      JSON.stringify(loot.worldCoordinates || {})
     ];
     await client.execute(query, values);
   } finally {

--- a/src/json/loot-info.json
+++ b/src/json/loot-info.json
@@ -11,7 +11,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631007046205458_NSLOCTEXT(\"\", \"684322974B7ECFB703DE418573F18428\", \"The Blood Rune\")_NSLOCTEXT(\"\", \"16307644421FD5D370B52A9427CB68C4\", \"Find the goblin Blood Rune in the Aela Ruins.\")",
@@ -25,7 +26,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632580968288242_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"951E05FD4E1A980E7EB21088A312E1BA\", \"Top of the Arch\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"EC4BA7CC416E445E300AF7B68A3D51A0\", \"Find the dig site atop the arch.\")",
@@ -39,7 +41,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633300667531302_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5A2BCBE040B6216D119C51AAEAC9F7C5\", \"X Marks the Spot\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"609AC7A442B736C5E80A3CBBDB0DDFBC\", \"Follow the map.\")",
@@ -53,7 +56,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632580996403187_NSLOCTEXT(\"\", \"744F9DA84CF32BBB5BE5ADB2553C67FA\", \"The Precarious Keep\")_NSLOCTEXT(\"\", \"21FD305743A4CCFD9C4404AA51D0239B\", \"Find the dig site at the sliding ruins.\")",
@@ -67,7 +71,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581004201972_NSLOCTEXT(\"\", \"3D9E09634051E473388CCB836F29AB88\", \"Isle in the Stream\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"49DE5348489B71E98982BAA0A897B120\", \"Find the dig site at the vale with a stream.\")",
@@ -81,7 +86,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581013770229_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"AA7692D74C0650544EB998B2EDC719F1\", \"On the Shelf\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"E3A1243949F6697C42ADBFBE3A29BF45\", \"Find the dig site near Baneswood Cemetery.\")",
@@ -95,7 +101,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631272567341059_NSLOCTEXT(\"\", \"750A85B64F3B64B7CD36D38C0D307BAE\", \"Cloak and Gavel\")_NSLOCTEXT(\"\", \"059B30184FE3D879CB1AB298AA44ADA4\", \"Find the chest that the Cloak and Gavel key opens.\")",
@@ -109,7 +116,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581020520438_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"34DE3B274389E9932594C892A2DA494D\", \"High Along the Ridge\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"54CD1E8841FD7B16E6ED3F8B0B4D1736\", \"Locate the dig site.\")",
@@ -123,7 +131,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581026877431_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"565172D54999A4E0B81C0FAF94516D75\", \"The Talons Nest\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"007BE77B4116E7EEEF8034A660317201\", \"Locate the dig site.\")",
@@ -137,7 +146,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581030612984_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"FB47530C45FBCE61213FF4BD0505FFEB\", \"The Walls Came Down\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"72A7BA454C2FA512BB08D6A9FBF167DD\", \"Locate the dig site.\")",
@@ -151,7 +161,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581038280697_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"CC3007C84E3C24F515A42BADFB184299\", \"The Megalithic Mage\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"10DA0D9F45F5A18C395337B098C02058\", \"Locate the dig site.\")",
@@ -165,7 +176,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581044441082_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"8FD16DD64C1305E49D713090D9ED7DF6\", \"The Isle of Monolith and Horn\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A2F70785405DDE8F6D44BDA787A98E78\", \"Locate the dig site.\")",
@@ -179,7 +191,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632581054599163_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5E536BD3477D534DFAB2DF8E9376EDE5\", \"The Distant Dome\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"3108F8AD4AD108DE31A0BEBE42398D72\", \"Locate the dig site.\")",
@@ -193,7 +206,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631555698589764_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"4B4C42054FD18F3ED7200E973312C6FD\", \"Set To Motion\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"89822AD84262CA91230874BFEFC032F2\", \"Find the Tower of Bellsong\")",
@@ -207,7 +221,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632282706280463_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"6F96DE4A4C9601F1F0CA84A70CAE1D41\", \"Challenge of Carphin\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"147B916F478836437EF7BFB7D23EE776\", \"Find the Bellsong Chest in Carphin\")",
@@ -221,7 +236,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631555341025290_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"ED8AD3034BFA5B4E67B3A89B64ADA5FD\", \"The Power of the Dead\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"99910776402713FCF79D3DAA1CA2A0CE\", \"\\\"Let the power of the dead pry open the maw.\\\"\")",
@@ -235,7 +251,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631596144984097_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"8FDB7BB445AC414E4F0287BB0BC27C1E\", \"The Tower and the Wolf\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"C07EFF3847ADEE05D6E2CBADDF354422\", \"Investigate the Tower and Wolf crest\")",
@@ -249,7 +266,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289861759469_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"8FDB7BB445AC414E4F0287BB0BC27C1E\", \"The Tower and the Wolf\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"C07EFF3847ADEE05D6E2CBADDF354422\", \"Investigate the Tower and Wolf crest\")",
@@ -263,7 +281,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631601717381436_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"2D8BE06548046CD08AA5838017821E35\", \"The Shining Shield\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"990F4B834B76C5E44FD7C89D862A692C\", \"Find the secret purpose of the Refurbished Shiny Sheild\")",
@@ -277,7 +296,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633300672905255_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"2D8BE06548046CD08AA5838017821E35\", \"The Shining Shield\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"990F4B834B76C5E44FD7C89D862A692C\", \"Find the secret purpose of the Refurbished Shiny Sheild\")",
@@ -291,7 +311,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289869754909_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"C089ECF246BE527913FE5388FC85AC03\", \"The Stones of Tura\\'Madu\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"23C6F60840C8A9BCE3683AA30ADAA09D\", \"Acquire the Stones of Tura\\'Madu\")",
@@ -305,7 +326,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631641441763355_NSLOCTEXT(\"[D20C99C24B2FABB4DC05E3BF1EE067C5]\", \"D673CC4D48FC0CEEE96C5BA40B5E5803\", \"Raiders of the Cursed Archives\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5331592742F47133D22BA896433BA653\", \"Stop those who wish to claim the Collar of Vuul\")",
@@ -319,7 +341,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633300745912360_NSLOCTEXT(\"[D20C99C24B2FABB4DC05E3BF1EE067C5]\", \"D673CC4D48FC0CEEE96C5BA40B5E5803\", \"Raiders of the Cursed Archives\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5331592742F47133D22BA896433BA653\", \"Stop those who wish to claim the Collar of Vuul\")",
@@ -333,7 +356,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631234388885827_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"6EE8811D452E1F880F7C7EB0AD2B7704\", \"The Blood Hunt\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A03765F645A23BE11BB409806848D006\", \"You are posessed with a wild bloodlust, the minotaur must be culled.\")",
@@ -347,7 +371,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631686863651107_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"2366D669419F8A59359162AD1FB0506C\", \"Justice and Redemption\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"AC9CD9AE4F8920B87A4C20B7D98461C7\", \"Find the escaped prisoner, Splint\")",
@@ -361,7 +386,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631742681907223_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"37A6C3EE4DB6F25DE1982C847F7B6191\", \"The Key to Thanalus\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"DF3BDF2B409B4B97D655F1875A8382DB\", \"Recover the Stone Rose\")",
@@ -375,7 +401,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631720014250102_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"8F0C436544DBCFEAEF1875822887636A\", \"The Hide Words\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A0783FE7470D6ED09BE0D89408440A38\", \"Decipher the glyphs in the Minotaur Hide Word.\")",
@@ -389,7 +416,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064630197017968712_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A915B7F04869E2842DAE0B9E36271968\", \"Horns of the Betrayers\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"77FD2F754DD90A7C655E63AE0F736D60\", \"Retrieve the Three Horns of Betrayers\")",
@@ -403,7 +431,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631884219154458_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"D1E7078D49A160AB218592A73806E2E0\", \"Of Wicked Intent\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"8636F6794DDD54903334DFB311782997\", \"Find out why the cultists are at the cathedral\")",
@@ -417,7 +446,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632756940963923_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"E5C1558245BD63001908BABEDA4D35DE\", \"Honor the Brave\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A54E7DF247DE2EEC6C17749DA2B6FB24\", \"Toss a Fallen Purfier Skull in the Ashen Pyre\")",
@@ -431,7 +461,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632756948697173_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"AFECCAF940F272E8CF936F89B287AF48\", \"The Ruins of Warhelm\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"0FE220DC46042BFFF77BE292D68DE865\", \"Locate the recorded sites within the Warhelm Garrison\")",
@@ -445,7 +476,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632225013366824_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"DDC5F29C4616BE6E94BA0EBCDA506447\", \"The Stash\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"B0061AA8436BBDE051BDD5BFF93FB366\", \"Find Galen\\'s lock box at Nika Brae.\")",
@@ -459,7 +491,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632756941422676_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"36FC5B2744C0BD02A32C489117B91B71\", \"Echoes of Betrayal\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"64CA8A0A4BBD8CBDDD79178A8C5D8B4C\", \"Uncover the origin of the Curse of Warhelm.\")",
@@ -473,7 +506,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632756940701778_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"69EADBCC4D59893E75EE7E8616077E5F\", \"The Breath of Kyronu\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"CBB3AB3B4FA2D6E0316C5B9F9BFA0CBB\", \"Ignite the Purification Censers found in Warhelm Garrison\")",
@@ -487,7 +521,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632275376734242_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"B5386F664CB8FC080FF8D992DFC79AB0\", \"Package For Briarhome\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"3B948A704BE01423B43B46A547AA1EA1\", \"Deliver package to Lady Fiona at Briarmoor Farms\")",
@@ -501,7 +536,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632746637001029_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"6CAED75141E74EFE03E83681CECABACD\", \"Got Goblin Goods?\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"2ECE445C4CA5FDB7B29504895400933E\", \"Fulfill the List of Goblin Goods\")",
@@ -515,7 +551,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289863856625_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"66BCEDBD49716B747DC7EEAEE1B4A228\", \"Welcome to the Larder\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"424FBE0F46C9EC62E30663BD6F801451\", \"Assist the frontline forces at the Second Sword outpost.\")",
@@ -529,7 +566,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289867198984_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"210D37E342EAA3A3319FAB8065CD3FD8\", \"The Road to Joeva\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"D0809B154B47D105F81859B818730786\", \"Check in to each Watch Tower on the Road to Joeva. \")",
@@ -543,7 +581,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289859858921_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"B374D6044561F2DF466B189D844984AC\", \"A Giant Threat\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"C4F5BEB84FA74225EC0268ABB13B380B\", \"Recover the titan artifact, the Eye of Esh.\")",
@@ -557,7 +596,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064630417660968995_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"13A08CC048A85BDD62091AACD004A5DB\", \"A New Order\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5D112AF940B2CF1042088F99707010E0\", \"Meet Galein\\'s crew and collect information on Sephilion.\")",
@@ -571,7 +611,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632025123913728_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"1BE100CF424693ACF7A09197F4BB9B32\", \"Ace in the Hole\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5721DF3D4D3F9869D61EFD9F0EC4A978\", \"Find Sweeney and bring back the rest of the manifests.\")",
@@ -585,7 +626,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064630417664377094_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"D5F9F22A45D651DC893721BBD9C44FE7\", \"Distant Relatives\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A8CC56F34BA3E181E9590AA08D8C08B0\", \"Recapture lost possessions from the Honorsworn Tower.\")",
@@ -599,7 +641,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064630417664311554_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"D5F9F22A45D651DC893721BBD9C44FE7\", \"Distant Relatives\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"A8CC56F34BA3E181E9590AA08D8C08B0\", \"Recapture lost possessions from the Honorsworn Tower.\")",
@@ -613,7 +656,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631714157232129_NSLOCTEXT(\"[E264E66C390A6CBB3202881017FD4BB6]\", \"B9DE65EC4F29E3C5741594979CFA346E\", \"Cleaning the Books\")_NSLOCTEXT(\"[E264E66C390A6CBB3202881017FD4BB6]\", \"2183A4F04C9759DDF74F06AAB5125A88\", \"Deliver the found manifests to New Aela.\")",
@@ -627,7 +671,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064632750946517001_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"E55F37A44D6429423F29C9BF517F5292\", \"The Whispering Skulls\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"655D060D4073B2CA245B5E8F0816970A\", \"Take the Whispering Skulls to \\\"Death\\'s Pulpit.\\\"\")",
@@ -641,7 +686,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633017578750055_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"8A2629964949653C5EEACE9A3F7E0561\", \"The Cypher of Scrolls\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"C50B692A4C25012C269A99A7F4F1C3FB\", \"Get rubbings from the lost Pillars of Al\\'Ashal\")",
@@ -655,7 +701,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289874080307_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"88F64DCA46387A7BDF500EBE9880985C\", \"Scrolls of Mirajinn: The Calling of Al\\\"Ashal\")_NSLOCTEXT(\"[70199B914E7E03A9706A1499CF20B1FD]\", \"5B9DACCC49433A3D7C2B618113A525CF\", \"Collect the lost artifact of Al\\'Ashal\")",
@@ -669,7 +716,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064631986903711765_NSLOCTEXT(\"[209044794D46EB6C6398F37EEAE2669D]\", \"F12885B844AC60B40F12FF911D65B8D9\", \"Full Objective Interaction Test\")_COM_AutomationQuestInteraction",
@@ -683,7 +731,8 @@
     "zone": null,
     "spawnRate": null,
     "dropChance": null,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633290466394115_PA_RVR_Carphin_ZombieScholar_L29_3S_RareSpawn_TheWearyConstructor_552.7952187393676_-1034.28251237917_21011.25907723453",
@@ -697,11 +746,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 552.7952187393676,
       "y": -1034.28251237917,
       "z": 21011.25907723453
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633290456891394_PA_Befallen_Dunir_Berserker_L29_4S_RareSpawn_Forgelord Zammer_0_0_0",
@@ -715,7 +765,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633290456891394_PA_Befallen_Dunir_Berserker_L29_4S_RareSpawn_Forgelord Zammer_269.49182207416743_-20787.90148087591_-5558.959277848999",
@@ -729,11 +780,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1800,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 269.49182207416743,
       "y": -20787.90148087591,
       "z": -5558.959277848999
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064632983871488126_PA_SAN_Brood_Pit_Scorpion_Giant_L26_3S_RareSpawn_Tawlbura_-6530.5692120525055_1984.3340108091943_-26155.762064006085",
@@ -747,11 +799,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -6530.5692120525055,
       "y": 1984.3340108091943,
       "z": -26155.762064006085
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633267284410371_PA_SAN_Brood_Pit_Scorpion_Giant_L26_3S_RareSpawn_Tawlbura_-6530.5692120525055_1984.3340108091943_-26155.762064006085",
@@ -765,11 +818,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -6530.5692120525055,
       "y": 1984.3340108091943,
       "z": -26155.762064006085
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064632983871946879_PA_SAN_Brood_Pit_Scorpian_Giant_L25_3S_RareSpawn_Ahmdar_-9563.84506951063_5642.39412609092_-26731.42957571052",
@@ -783,11 +837,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -9563.84506951063,
       "y": 5642.39412609092,
       "z": -26731.42957571052
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064632983870898301_PA_SAN_Lost_Hero_Sepulcher_Ocular_L18_2S_RareSpawn_KhgIzp_5055.499970710633_-8201.257233468816_-25358.210047304216",
@@ -801,11 +856,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 5055.499970710633,
       "y": -8201.257233468816,
       "z": -25358.210047304216
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064632983876272261_PA_SAN_Lost_Hero_Sepulcher_Flesh_Golem_L18_2S_RareSpawn_Lost_Hero_4171.114559930807_-14920.908698011539_-25277.319512070237",
@@ -819,11 +875,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 4171.114559930807,
       "y": -14920.908698011539,
       "z": -25277.319512070237
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064632983870046332_PA_SAN_Pocket_Dungeons_Scarabsong_Hollow_Crimson_Giant_Scarab_L20_2S_RareSpawn_Scarab_Patriarch_-6918.533556380949_-4137.405094491201_6232.293842139098",
@@ -837,11 +894,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -6918.533556380949,
       "y": -4137.405094491201,
       "z": 6232.293842139098
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064632983869456507_PA_SAN_Pocket_Dungeons_Scarabsong_Hollow_Crimson_Giant_Scarab_L120_2S_RareSpawn_Scarab_Matriarch_-3958.9927023786586_-8591.782412739238_8463.985412972042",
@@ -855,11 +913,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -3958.9927023786586,
       "y": -8591.782412739238,
       "z": 8463.985412972042
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742535171_PA_SAN_Apothecarium_Dreadmire_Najash_Tracker_L32_2S_RareSpawn_Xirvethis_Despoiler_-4699.605272311619_2455.841703388258_-355.8011359429793",
@@ -873,11 +932,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -4699.605272311619,
       "y": 2455.841703388258,
       "z": -355.8011359429793
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742666244_PA_SAN_Apothecarium_Dreadmire_Najash_Tracker_L31_2S_RareSpawn_Zhultaresh_-619.1504339082021_9247.38240689598_-380.2108373960036",
@@ -891,11 +951,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -619.1504339082021,
       "y": 9247.38240689598,
       "z": -380.2108373960036
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742731781_PA_SAN_Stone_Hold_Giant_L32_3S_RareSpawn_Lokk_Ragebringer_-5390.196410311852_11636.912381178234_-39123.1138892401",
@@ -909,11 +970,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -5390.196410311852,
       "y": 11636.912381178234,
       "z": -39123.1138892401
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742862854_PA_SAN_Stone_Hold_Giant_L31_3S_RareSpawn_Dom_Champion_608.3941275151155_8913.652340909699_-39705.12309028996",
@@ -927,11 +989,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 608.3941275151155,
       "y": 8913.652340909699,
       "z": -39705.12309028996
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633135978381393_NPC_Crocodile_Leathermaw_-315.8586743201013_-264.6663612301927_-22.458822598824554",
@@ -945,11 +1008,12 @@
     "zone": null,
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -315.8586743201013,
       "y": -264.6663612301927,
       "z": -22.458822598824554
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633135978381393_NPC_Crocodile_Leathermaw_-614.2246720315889_-5754.241669391398_-653.5563345132032",
@@ -963,11 +1027,12 @@
     "zone": null,
     "spawnRate": 150,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -614.2246720315889,
       "y": -5754.241669391398,
       "z": -653.5563345132032
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633135978971218_PA_SAN_Pocket_Dungeons_Moonrock_Mesa_Desert_Giant_L17_3S_RareSpawn_Sungazer_Murgo_50928.00753313117_-14163.310229247785_23751.303771970815",
@@ -981,11 +1046,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 50928.00753313117,
       "y": -14163.310229247785,
       "z": 23751.303771970815
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742993927_PA_SAN_GypsumOutpost_Reaper_L30_3S_RareSpawn_NearlyDeadPrisoner_0_0_0",
@@ -999,7 +1065,8 @@
     "zone": null,
     "spawnRate": 5400,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742993927_PA_SAN_GypsumOutpost_Reaper_L30_3S_RareSpawn_NearlyDeadPrisoner_123.82034416589886_-247.91358608868904_50.000010129489965",
@@ -1013,11 +1080,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 123.82034416589886,
       "y": -247.91358608868904,
       "z": 50.000010129489965
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633293452017723_PA_SAN_GypsumOutpost_Bandit_L29_2S_RareSpawn_SharpclawTalrith_0_0_0",
@@ -1031,7 +1099,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633293452017723_PA_SAN_GypsumOutpost_Bandit_L29_2S_RareSpawn_SharpclawTalrith_120.22565639880486_-385.99254308082163_996.0000250899875",
@@ -1045,11 +1114,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 120.22565639880486,
       "y": -385.99254308082163,
       "z": 996.0000250899875
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288997994506_PA_SAN_Communion_Cultist_L30_3S_RareSpawn_VoidspeakerTelmont_0_0_0",
@@ -1063,7 +1133,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633288997994506_PA_SAN_Communion_Cultist_L30_3S_RareSpawn_VoidspeakerTelmont_223.18619808998483_-441.9506721475627_46.00000748668208",
@@ -1077,11 +1148,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 223.18619808998483,
       "y": -441.9506721475627,
       "z": 46.00000748668208
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742404098_PA_SAN_Communion_Warbear_L29_3S_RareSpawn_MiserableDustpaw_0_0_0",
@@ -1095,7 +1167,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742404098_PA_SAN_Communion_Warbear_L29_3S_RareSpawn_MiserableDustpaw_1101.9521521591596_-471.28961485414766_-853.999969970564",
@@ -1109,11 +1182,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 1101.9521521591596,
       "y": -471.28961485414766,
       "z": -853.999969970564
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742207489_PA_SAN_Communion_BanditCaptain_L29_3S_RareSpawn_WartrainerRhogan_0_0_0",
@@ -1127,7 +1201,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742207489_PA_SAN_Communion_BanditCaptain_L29_3S_RareSpawn_WartrainerRhogan_439.4155160551454_-754.2512992997654_-844.9949220706676",
@@ -1141,11 +1216,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 439.4155160551454,
       "y": -754.2512992997654,
       "z": -844.9949220706676
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742076416_PA_SAN_Communion_BanditCaptain_L29_3S_RareSpawn_CaptainTharsus_0_0_0",
@@ -1159,7 +1235,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633288742076416_PA_SAN_Communion_BanditCaptain_L29_3S_RareSpawn_CaptainTharsus_-2032.5938523292643_2902.887309626676_-853.9999802564198",
@@ -1173,11 +1250,12 @@
     "zone": null,
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -2032.5938523292643,
       "y": 2902.887309626676,
       "z": -853.9999802564198
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012281371_PA_TUR_Coral_Grotto_Reaper_L25_2S_RareSpawn_Tidewarden_0_0_0",
@@ -1191,7 +1269,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012281371_PA_TUR_Coral_Grotto_Reaper_L25_2S_RareSpawn_Tidewarden_4735.7932119248435_6166.620588718215_1094.9418529449122",
@@ -1205,11 +1284,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 4735.7932119248435,
       "y": 6166.620588718215,
       "z": 1094.9418529449122
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012346908_PA_TUR_Coral_Grotto_FlamingSkeleton_L25_2S_RareSpawn_AriatheFlamebearer_0_0_0",
@@ -1223,7 +1303,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012346908_PA_TUR_Coral_Grotto_FlamingSkeleton_L25_2S_RareSpawn_AriatheFlamebearer_8463.598189749056_7193.895995203522_1132.999814911026",
@@ -1237,11 +1318,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 8463.598189749056,
       "y": 7193.895995203522,
       "z": 1132.999814911026
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002450955_PA_TUR_TheBrig_FleshGolem_L30_4S_RareSpawn_TheShackled_0_0_0",
@@ -1255,7 +1337,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002450955_PA_TUR_TheBrig_FleshGolem_L30_4S_RareSpawn_TheShackled_482.56262628617696_399.3066065967141_-445.5574680534737",
@@ -1269,11 +1352,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1800,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 482.56262628617696,
       "y": 399.3066065967141,
       "z": -445.5574680534737
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002582028_PA_TUR_TheBrig_Cultist_L30_3S_RareSpawn_TheBrinefather_0_0_0",
@@ -1287,7 +1371,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002582028_PA_TUR_TheBrig_Cultist_L30_3S_RareSpawn_TheBrinefather_2569.014294042019_-1002.5341664720327_370.4424251681685",
@@ -1301,11 +1386,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 2569.014294042019,
       "y": -1002.5341664720327,
       "z": 370.4424251681685
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002713101_PA_TUR_TheBrig_PirateSkelton_L30_2S_RareSpawn_CaptainBulwark_0_0_0",
@@ -1319,7 +1405,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002713101_PA_TUR_TheBrig_PirateSkelton_L30_2S_RareSpawn_CaptainBulwark_-1357.4373754174449_-2450.6933964453347_374.4424861701591",
@@ -1333,11 +1420,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -1357.4373754174449,
       "y": -2450.6933964453347,
       "z": 374.4424861701591
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012412445_PA_TUR_Coral_Grotto_RockElemental_L25_2S_RareSpawn_CoralColossus_0_0_0",
@@ -1351,7 +1439,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012412445_PA_TUR_Coral_Grotto_RockElemental_L25_2S_RareSpawn_CoralColossus_1236.7245850991458_156.25781713222386_2678.6205064767137",
@@ -1365,11 +1454,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 1236.7245850991458,
       "y": 156.25781713222386,
       "z": 2678.6205064767137
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003106321_PA_TUR_RuinsOfSholfire_FlameElemental_L17_3S_RareSpawn_Tolox_0_0_0",
@@ -1383,7 +1473,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003106321_PA_TUR_RuinsOfSholfire_FlameElemental_L17_3S_RareSpawn_Tolox_-1166.9439600415062_-441.38203743257327_-1653.0949920132534",
@@ -1397,11 +1488,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -1166.9439600415062,
       "y": -441.38203743257327,
       "z": -1653.0949920132534
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003237394_PA_TUR_RuinsOfSholfire_DunirUndeadMage_L17_3S_RareSpawn_CognockerEddis_0_0_0",
@@ -1415,7 +1507,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003237394_PA_TUR_RuinsOfSholfire_DunirUndeadMage_L17_3S_RareSpawn_CognockerEddis_-2497.219684834592_-713.4435235396086_2805.4425216473646",
@@ -1429,11 +1522,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -2497.219684834592,
       "y": -713.4435235396086,
       "z": 2805.4425216473646
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003302931_PA_TUR_RuinsOfSholfire_Skeleton_L17_3S_RareSpawn_ProfessorGurax_0_0_0",
@@ -1447,7 +1541,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003302931_PA_TUR_RuinsOfSholfire_Skeleton_L17_3S_RareSpawn_ProfessorGurax_-1172.3906399484258_-78.50683701658272_1912.1049913145089",
@@ -1461,11 +1556,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -1172.3906399484258,
       "y": -78.50683701658272,
       "z": 1912.1049913145089
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003696148_PA_TUR_PyrespireVent_MagmaGolem_L22_3S_RareSpawn_ZephrastheMolten_0_0_0",
@@ -1479,7 +1575,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003696148_PA_TUR_PyrespireVent_MagmaGolem_L22_3S_RareSpawn_ZephrastheMolten_6085.588364_-2238.039077_125.290858",
@@ -1493,11 +1590,12 @@
     "zone": null,
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 6085.588364,
       "y": -2238.039077,
       "z": 125.290858
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003958293_PA_TUR_PyrespireVent_RockElemental_L22_2S_RareSpawn_Malgorach_0_0_0",
@@ -1511,7 +1609,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003958293_PA_TUR_PyrespireVent_RockElemental_L22_2S_RareSpawn_Malgorach_2105.588364_146.960923_-52.524957",
@@ -1525,11 +1624,12 @@
     "zone": null,
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 2105.588364,
       "y": 146.960923,
       "z": -52.524957
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289004679190_PA_TUR_PyrespireVent_FireBeetle_L22_2S_RareSpawn_MoltenQueen_0_0_0",
@@ -1543,7 +1643,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289004679190_PA_TUR_PyrespireVent_FireBeetle_L22_2S_RareSpawn_MoltenQueen_9001.003595_611.85699_10.732298",
@@ -1557,11 +1658,12 @@
     "zone": null,
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 9001.003595,
       "y": 611.85699,
       "z": 10.732298
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289011888152_PA_TUR_PyrespireVent_FlameElemental_L22_2S_RareSpawn_Arzach_0_0_0",
@@ -1575,7 +1677,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633289011888152_PA_TUR_PyrespireVent_FlameElemental_L22_2S_RareSpawn_Arzach_3770.588364_-7063.039077_19.980934",
@@ -1589,11 +1692,12 @@
     "zone": null,
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 3770.588364,
       "y": -7063.039077,
       "z": 19.980934
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002844174_PA_TUR_Pocket_Dungeons_Farfathom_Caves_Living_Geode_3star_L16_3S_RareSpawn_Brightmound_1201.0687704235315_18112.17450816851_265.7070957586293",
@@ -1607,11 +1711,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 1201.0687704235315,
       "y": 18112.17450816851,
       "z": 265.7070957586293
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289002909711_PI_TUR_Pocket_Dungeons_Farfathom_Caves_Hoarder_3star_L16_3S_RareSpawn_Sirensong_Box_2876.194988796953_18704.919397138572_216.41855782237235",
@@ -1625,11 +1730,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 2876.194988796953,
       "y": 18704.919397138572,
       "z": 216.41855782237235
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289003040784_PA_TUR_Pocket_Dungeons_Farfathom_Caves_Animated_Armor_L16_3S_RareSpawn_Deadmans_Armor_-2617.0459387721494_14448.332676152408_160.9236395110056",
@@ -1643,11 +1749,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -2617.0459387721494,
       "y": 14448.332676152408,
       "z": 160.9236395110056
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633288743256073_TUR_Pocket_Dungeon_Multroks_Fall_Kesatal_1420.2969915482681_-12543.48319803126_-48253.722329479235",
@@ -1661,11 +1768,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 1420.2969915482681,
       "y": -12543.48319803126,
       "z": -48253.722329479235
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289007104023_PA_TUR_Pocket_Dungeon_Multroks_Fall_Bat_Vampire_L30_2S_RareSpawn_Specimen_Twelve_2109.1308803674765_-13747.335308962734_-48328.2254790879",
@@ -1679,11 +1787,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 2109.1308803674765,
       "y": -13747.335308962734,
       "z": -48328.2254790879
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633300372815906_TUR_Pocket_Dungeons_Multroks_Fall_Eye_of_Amathar_-773.3417375674471_-13515.354102295882_-48340.53563462237",
@@ -1697,11 +1806,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -773.3417375674471,
       "y": -13515.354102295882,
       "z": -48340.53563462237
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012019225_PA_TUR_Pocket_Dungeon_Isle_of_Bones_Sea_Giant_L30_3S_Malrhos_653.3686926320661_126.6554044947261_-52683.757651159714",
@@ -1715,11 +1825,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 653.3686926320661,
       "y": 126.6554044947261,
       "z": -52683.757651159714
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012150298_PA_TUR_Pocket_Dungeon_Isle_of_Bones_Sea_Giant_L29_3S_Tavra_5328.563510219799_4343.289195237099_-51926.748411999084",
@@ -1733,11 +1844,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 5328.563510219799,
       "y": 4343.289195237099,
       "z": -51926.748411999084
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012543518_PA_TUR_Pocket_Dungeon_Subalfire_Lighthouse_Fire_Elemental_L28_3S_RareSpawn_Lotox_-2306.024415867403_2374.351146594272_-79360.80489232994",
@@ -1751,11 +1863,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -2306.024415867403,
       "y": 2374.351146594272,
       "z": -79360.80489232994
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012609055_PA_TUR_Pocket_Dungeon_Subalfire_Lighthouse_Goblin_Shaman_L27_3S_RareSpawn_Voice_of_the_Flames_-2550.0682945880108_3576.433018563199_-74466.54862886749",
@@ -1769,11 +1882,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -2550.0682945880108,
       "y": 3576.433018563199,
       "z": -74466.54862886749
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633289012740128_TUR_Pocket_Dungeons_Subalfire_Lighthouse_Lamplighter_-700.6909924950451_3921.2897853970644_-79414.7822768593",
@@ -1787,11 +1901,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -700.6909924950451,
       "y": 3921.2897853970644,
       "z": -79414.7822768593
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430589768851_PA_JUN_Pocket_Dungeon_Bloomed_Maw_BogBrute_L32_2S_RareSpawn_TheGuardner_-431.729744866956_-424.666399955051_801.5949183689409",
@@ -1805,11 +1920,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -431.729744866956,
       "y": -424.666399955051,
       "z": 801.5949183689409
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430589047954_PA_JUN_Pocket_Dungeon_Bloomed_Maw_Poison_Bloomeria_L31_2S_RareSpawn_Bloomthorn_-560.5595026989467_3239.9470663773827_513.2720393122909",
@@ -1823,11 +1939,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -560.5595026989467,
       "y": 3239.9470663773827,
       "z": 513.2720393122909
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430597567648_PA_JUN_Pit_Of_Golgora_Flame_Elemental_L27_3S_Rarespawn_Kuu'ShuuTheFlameForge_0_0_0",
@@ -1841,7 +1958,8 @@
     "zone": null,
     "spawnRate": 5400,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430597567648_PA_JUN_Pit_Of_Golgora_Flame_Elemental_L27_3S_Rarespawn_Kuu'ShuuTheFlameForge_0_0_0",
@@ -1855,7 +1973,8 @@
     "zone": null,
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430597567648_PA_JUN_Pit_Of_Golgora_Flame_Elemental_L27_3S_Rarespawn_Kuu'ShuuTheFlameForge_0_0_0",
@@ -1869,7 +1988,8 @@
     "zone": null,
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430597567648_PA_JUN_Pit_Of_Golgora_Flame_Elemental_L27_3S_Rarespawn_Kuu'ShuuTheFlameForge_4484.569981545908_1323.7846891807858_-15.836752260500361",
@@ -1883,11 +2003,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 4484.569981545908,
       "y": 1323.7846891807858,
       "z": -15.836752260500361
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430595142812_PA_JUN_PoolsOfStench_Birdman_Warrior_L40_2S_Rarespawn_TalonMasterFolkan_0_0_0",
@@ -1901,7 +2022,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430595142812_PA_JUN_PoolsOfStench_Birdman_Warrior_L40_2S_Rarespawn_TalonMasterFolkan_-8712.955783421407_6042.7417289109435_-279.58959688162577",
@@ -1915,11 +2037,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -8712.955783421407,
       "y": 6042.7417289109435,
       "z": -279.58959688162577
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430595732637_PA_JUN_PoolsOfStench_Birdman_Forager_L40_2S_Rarespawn_ShrillMasterGallea_0_0_0",
@@ -1933,7 +2056,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430595732637_PA_JUN_PoolsOfStench_Birdman_Forager_L40_2S_Rarespawn_ShrillMasterGallea_-6607.296928025084_5460.775935173617_-274.89306055345605",
@@ -1947,11 +2071,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -6607.296928025084,
       "y": 5460.775935173617,
       "z": -274.89306055345605
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430596387998_PA_JUN_PoolsOfStench_Birdman_Necromancer_L40_2S_Rarespawn_BindMasterHakoa_0_0_0",
@@ -1965,7 +2090,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430596387998_PA_JUN_PoolsOfStench_Birdman_Necromancer_L40_2S_Rarespawn_BindMasterHakoa_-10265.302993391873_6226.731603364227_-297.18461740451585",
@@ -1979,11 +2105,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -10265.302993391873,
       "y": 6226.731603364227,
       "z": -297.18461740451585
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430596977823_PA_JUN_PoolsOfStench_Giant_Ooze_L41_2S_Rarespawn_TheAnointer_0_0_0",
@@ -1997,7 +2124,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430596977823_PA_JUN_PoolsOfStench_Giant_Ooze_L41_2S_Rarespawn_TheAnointer_-6408.640423978446_6969.715034623281_268.5041647538919",
@@ -2011,11 +2139,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -6408.640423978446,
       "y": 6969.715034623281,
       "z": 268.5041647538919
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430592259223_PA_JUN_Pocket_Dungeon_Murmuring_Root_BogBrute_L39_2S_RareSpawn_Lore_Warden_6024.051848019939_6652.717618337367_1043.4516691680947",
@@ -2029,11 +2158,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 6024.051848019939,
       "y": 6652.717618337367,
       "z": 1043.4516691680947
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430591669398_PA_JUN_Pocket_Dungeon_Murmuring_Root_Zombie_Drowned_L38_2S_RareSpawn_Entangled_Horticulturalist_-1347.1895198604325_653.2497205520049_117.32050065108706",
@@ -2047,11 +2177,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -1347.1895198604325,
       "y": 653.2497205520049,
       "z": 117.32050065108706
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633453086376386_PA_JUN_KrakenBelly_Pirate_Raider_L25_2S_Rarespawn_Brinebeard_0_0_0",
@@ -2065,7 +2196,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633453086376386_PA_JUN_KrakenBelly_Pirate_Raider_L25_2S_Rarespawn_Brinebeard_2089.3125269904267_3582.2412961075315_64.18693687625364",
@@ -2079,11 +2211,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 2089.3125269904267,
       "y": 3582.2412961075315,
       "z": 64.18693687625364
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430590555284_PA_JUN_KrakenBelly_Pirate_Bard_L25_2S_Rarespawn_ShantyShawn_0_0_0",
@@ -2097,7 +2230,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430590555284_PA_JUN_KrakenBelly_Pirate_Bard_L25_2S_Rarespawn_ShantyShawn_6884.130193821387_5815.942299838294_-656.3741674568673",
@@ -2111,11 +2245,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 6884.130193821387,
       "y": 5815.942299838294,
       "z": -656.3741674568673
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430590555284_PA_JUN_KrakenBelly_Pirate_Bard_L25_2S_Rarespawn_ShantyShawn_4937.978388882009_7858.137154917349_477.33469068120576",
@@ -2129,11 +2264,12 @@
     "zone": null,
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 4937.978388882009,
       "y": 7858.137154917349,
       "z": 477.33469068120576
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633453091750340_PA_JUN_KrakenBelly_Pirate_Captain_L26_2S_Rarespawn_BarnacleBrenn_0_0_0",
@@ -2147,7 +2283,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633453091750340_PA_JUN_KrakenBelly_Pirate_Captain_L26_2S_Rarespawn_BarnacleBrenn_2996.667770285392_7313.742433227948_44.916071837667914",
@@ -2161,11 +2298,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 2996.667770285392,
       "y": 7313.742433227948,
       "z": 44.916071837667914
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430594552987_PA_JUN_Pocket_Dungeon_Web_Well_Spider_Giant_Jungle_L31_3S_RareSpawn_Viirmythus_5391.447693915106_-1379.7276527807117_-300.49546739897596",
@@ -2179,11 +2317,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 5391.447693915106,
       "y": -1379.7276527807117,
       "z": -300.49546739897596
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430592849048_PA_JUN_HollowOracle_Basilisk_L40_3S_Rarespawn_IronhideBasilisk_0_0_0",
@@ -2197,7 +2336,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430592849048_PA_JUN_HollowOracle_Basilisk_L40_3S_Rarespawn_IronhideBasilisk_12605.47434834647_3464.7359545261133_889.867404510871",
@@ -2211,11 +2351,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 12605.47434834647,
       "y": 3464.7359545261133,
       "z": 889.867404510871
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633453159711173_PA_JUN_HollowOracle_Boakhar_Mage_L41_3S_Rarespawn_ZagrazootheEyeless_0_0_0",
@@ -2229,7 +2370,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633453159711173_PA_JUN_HollowOracle_Boakhar_Mage_L41_3S_Rarespawn_ZagrazootheEyeless_10067.549382002791_-5044.905354559189_810.1052746225578",
@@ -2243,11 +2385,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 10067.549382002791,
       "y": -5044.905354559189,
       "z": 810.1052746225578
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430593963162_PA_JUN_Pocket_Dungeon_Web_Well_Spider_Giant_L30_3S_RareSpawn_Minereaver_0_0_0",
@@ -2261,7 +2404,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430593963162_PA_JUN_Pocket_Dungeon_Web_Well_Spider_Giant_L30_3S_RareSpawn_Minereaver_-8848.593414790463_661.3662843045313_384.23438223864105",
@@ -2275,11 +2419,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -8848.593414790463,
       "y": 661.3662843045313,
       "z": 384.23438223864105
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430599402659_PA_JUN_Pocket_Dungeon_Verdance_Ruins_Skelton_Knight_L22_2S_RareSpawn_Lady_Aislinn_the_Hawk_0_0_0",
@@ -2293,7 +2438,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430599402659_PA_JUN_Pocket_Dungeon_Verdance_Ruins_Skelton_Knight_L22_2S_RareSpawn_Lady_Aislinn_the_Hawk_-2771.3812282053987_-4618.195405679406_962.9141639572226",
@@ -2307,11 +2453,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": -2771.3812282053987,
       "y": -4618.195405679406,
       "z": 962.9141639572226
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430605235373_PA_JUN_Pocket_Dungeon_Verdance_Ruins_Skeleton_Reaper_L22_2S_RareSpawn_Sir_Jenry_The_Strong_0_0_0",
@@ -2325,7 +2472,8 @@
     "zone": null,
     "spawnRate": 0,
     "dropChance": 1,
-    "coordinates": null
+    "zoneCoordinates": null,
+    "worldCoordinates": null
   },
   {
     "id": "6064633430605235373_PA_JUN_Pocket_Dungeon_Verdance_Ruins_Skeleton_Reaper_L22_2S_RareSpawn_Sir_Jenry_The_Strong_1724.8750931199174_-12737.415309713106_-1722.3165975619959",
@@ -2339,11 +2487,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 900,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 1724.8750931199174,
       "y": -12737.415309713106,
       "z": -1722.3165975619959
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430598812834_PA_JUN_Pocket_Dungeon_AshenHauntKing_L43_3S_RareSpawn_Echo_of_Atrax_4952.452394316555_10511.404819666408_14986.130616982009",
@@ -2357,11 +2506,12 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 4952.452394316555,
       "y": 10511.404819666408,
       "z": 14986.130616982009
-    }
+    },
+    "worldCoordinates": null
   },
   {
     "id": "6064633430598157473_PA_JUN_Pocket_Dungeon_AshenHauntKing_L42_3S_RareSpawn_Thalora_8072.452394316555_3821.404819666408_15427.994990053296",
@@ -2375,10 +2525,11 @@
     "zone": "Verra_World_Master",
     "spawnRate": 1200,
     "dropChance": 1,
-    "coordinates": {
+    "zoneCoordinates": {
       "x": 8072.452394316555,
       "y": 3821.404819666408,
       "z": 15427.994990053296
-    }
+    },
+    "worldCoordinates": null
   }
 ]

--- a/src/processor/gear.js
+++ b/src/processor/gear.js
@@ -223,6 +223,7 @@ async function processItemGearFiles(directoryData) {
       const tables = itemToRewardTables[item.id] || [];
       const craftingRecipes = [];
       for (const rtId of tables) {
+        if (!rtId || rtId === "0") continue;
         if (!rewardTableCache[rtId]) {
           rewardTableCache[rtId] = getJson(
             directoryData,

--- a/src/processor/loot.js
+++ b/src/processor/loot.js
@@ -3,6 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import rewardMap from "../json/reward-id.json" with { type: "json" };
 import { saveLootInfoToDatabase } from "../db/operations.js";
+import { getJson, getItemJson, extractLastQuotedValue } from "../utils.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,6 +27,219 @@ function parseAssetDefKey(key) {
   return match ? match[1] : null;
 }
 
+// Cache for reward table lookups
+const rewardTableCache = {};
+const itemNameCache = {};
+const chanceCache = {};
+const poolSizeCache = {};
+
+/**
+ * Parse predicate expressions from reward tables to extract
+ * level ranges or biome restrictions.
+ * @param {string} expression
+ * @returns {{levelMin: number|null, levelMax: number|null, biome: string|null}}
+ */
+function parsePredicate(expression) {
+  const result = { levelMin: null, levelMax: null, biome: null };
+  if (!expression || typeof expression !== "string") return result;
+
+  const minMatch = expression.match(/GetNPCLevel\(\)\s*>=\s*(\d+)/);
+  const maxMatch = expression.match(/GetNPCLevel\(\)\s*<=\s*(\d+)/);
+  const biomeMatch = expression.match(/GetNodeBiome\(\)\s*==\s*EBiomeType::(\w+)/);
+
+  if (minMatch) result.levelMin = parseInt(minMatch[1], 10);
+  if (maxMatch) result.levelMax = parseInt(maxMatch[1], 10);
+  if (biomeMatch) result.biome = biomeMatch[1];
+  return result;
+}
+
+/**
+ * Load reward table predicates (level/biome).
+ * Results are cached to avoid redundant file reads.
+ * @param {string} baseDir - Root data directory
+ * @param {string} rtId - Reward table GUID
+ * @returns {{levelMin: number|null, levelMax: number|null, biome: string|null}}
+ */
+function getRewardTableInfo(baseDir, rtId) {
+  if (!rtId || rtId === "0") {
+    return { levelMin: null, levelMax: null, biome: null };
+  }
+  if (rewardTableCache[rtId]) return rewardTableCache[rtId];
+
+  const data = getJson(baseDir, "/Reward/RewardTable", `RewardTable_${rtId}.json`);
+  const info = { levelMin: null, levelMax: null, biome: null };
+
+  if (data?.predicate?.expression) {
+    const pred = parsePredicate(data.predicate.expression);
+    info.levelMin = pred.levelMin;
+    info.levelMax = pred.levelMax;
+    info.biome = pred.biome;
+  }
+
+  rewardTableCache[rtId] = info;
+  return info;
+}
+
+/**
+ * Get display name for an item by GUID.
+ * @param {string} baseDir
+ * @param {string} itemId
+ * @returns {string}
+ */
+function getItemName(baseDir, itemId) {
+  if (itemNameCache[itemId]) return itemNameCache[itemId];
+  const data = getItemJson(baseDir, "/Item/Item", itemId);
+  const name = extractLastQuotedValue(data.itemName) || "";
+  itemNameCache[itemId] = name;
+  return name;
+}
+
+/**
+ * Compute total number of item rewards reachable from a reward table.
+ * @param {string} baseDir
+ * @param {string} rtId
+ * @returns {number}
+ */
+function getPoolSize(baseDir, rtId) {
+  if (!rtId || rtId === "0") {
+    poolSizeCache[rtId] = 0;
+    return 0;
+  }
+  if (poolSizeCache[rtId] !== undefined) return poolSizeCache[rtId];
+
+  const data = getJson(baseDir, "/Reward/RewardTable", `RewardTable_${rtId}.json`);
+  if (!data || Object.keys(data).length === 0) {
+    poolSizeCache[rtId] = 0;
+    return 0;
+  }
+
+  const container = data?.rewardDefContainers?.[0];
+  const rewards = container?.rewards || [];
+  if (rewards.length) {
+    poolSizeCache[rtId] = rewards.length;
+    return rewards.length;
+  }
+
+  const subIds =
+    data.subTablesIds?.map((s) => s.guid).filter((id) => id && id !== "0") || [];
+  let total = 0;
+  for (const subId of subIds) {
+    total += getPoolSize(baseDir, subId);
+  }
+  poolSizeCache[rtId] = total;
+  return total;
+}
+
+/**
+ * Recursively compute the probability that a reward table yields a given item.
+ * Returns details about per-roll odds and roll counts.
+ * @param {string} baseDir - Root data directory
+ * @param {string} rtId - Reward table GUID
+ * @param {string} itemId - Item GUID to search for
+ * @returns {{chance:number, perRollChance:number, rolls:number, poolSize:number}}
+ */
+function computeItemChance(baseDir, rtId, itemId) {
+  const key = `${rtId}_${itemId}`;
+  if (!rtId || rtId === "0") {
+    chanceCache[key] = {
+      chance: 0,
+      perRollChance: 0,
+      rolls: 0,
+      poolSize: 0,
+    };
+    return chanceCache[key];
+  }
+  if (chanceCache[key]) return chanceCache[key];
+
+  const data = getJson(baseDir, "/Reward/RewardTable", `RewardTable_${rtId}.json`);
+  const totalPool = getPoolSize(baseDir, rtId);
+  if (!data || Object.keys(data).length === 0) {
+    chanceCache[key] = {
+      chance: 0,
+      perRollChance: 0,
+      rolls: 0,
+      poolSize: totalPool,
+    };
+    return chanceCache[key];
+  }
+
+  // Leaf table with item rewards
+  const container = data?.rewardDefContainers?.[0];
+  const rewards = container?.rewards || [];
+  if (rewards.length) {
+    const weights = container.weightsPerReward || [];
+    const rolls = container.numberToSelect || 1;
+    let totalWeight = 0;
+    for (let i = 0; i < rewards.length; i++) {
+      totalWeight += weights.length ? weights[i] ?? 1 : 1;
+    }
+    for (let i = 0; i < rewards.length; i++) {
+      const reward = rewards[i];
+      const items = reward.itemRewards || [];
+      const rId = items[0]?.item?.itemId?.guid;
+      const weight = weights.length ? weights[i] ?? 1 : 1;
+      if (rId === itemId) {
+        const perRoll = totalWeight > 0 ? weight / totalWeight : 0;
+        const chance = 1 - Math.pow(1 - perRoll, rolls);
+        chanceCache[key] = {
+          chance,
+          perRollChance: perRoll,
+          rolls,
+          poolSize: totalPool,
+        };
+        return chanceCache[key];
+      }
+    }
+  }
+
+  // Table with subtables
+  const subIds =
+    data.subTablesIds?.map((s) => s.guid).filter((id) => id && id !== "0") || [];
+  if (subIds.length) {
+    const rolls = data.numberOfSubtablesToSelect || 1;
+    let weights = data.weightsPerSubTable || [];
+    if (!weights.length && Array.isArray(data.expressionWeightsPerSubTable)) {
+      weights = data.expressionWeightsPerSubTable.map((e) => {
+        const match = e.expression.match(/:(\d+)/);
+        const n = match ? parseFloat(match[1]) : NaN;
+        return isNaN(n) ? 1 : n;
+      });
+    }
+    if (!weights.length) weights = new Array(subIds.length).fill(1);
+    const totalWeight = weights.reduce((sum, w) => sum + (w || 0), 0);
+    let totalChance = 0;
+    let perRollAccum = 0;
+    let rollAccum = 0;
+    for (let i = 0; i < subIds.length; i++) {
+      const subId = subIds[i];
+      const subWeight = weights[i] || 0;
+      const subChance = computeItemChance(baseDir, subId, itemId);
+      if (subChance.chance > 0) {
+        const perRoll = totalWeight > 0 ? subWeight / totalWeight : 0;
+        const selectChance = 1 - Math.pow(1 - perRoll, rolls);
+        totalChance += selectChance * subChance.chance;
+        perRollAccum = Math.max(perRollAccum, subChance.perRollChance);
+        rollAccum = Math.max(rollAccum, rolls * subChance.rolls);
+      }
+    }
+    chanceCache[key] = {
+      chance: totalChance,
+      perRollChance: perRollAccum,
+      rolls: rollAccum,
+      poolSize: totalPool,
+    };
+    return chanceCache[key];
+  }
+
+  chanceCache[key] = {
+    chance: 0,
+    perRollChance: 0,
+    rolls: 0,
+    poolSize: totalPool,
+  };
+  return chanceCache[key];
+}
+
 async function processLootFiles(directoryData) {
   const lootInfo = [];
 
@@ -36,12 +250,14 @@ async function processLootFiles(directoryData) {
     for (const file of walk(worldSpawnDir)) {
       const data = JSON.parse(fs.readFileSync(file, "utf8"));
       const mapName = data.mapName || "";
+      const name = data.name || "";
       if (data.populationSetsMap) {
         for (const entry of Object.values(data.populationSetsMap)) {
           if (entry.setId && entry.setId.guid) {
             worldSpawns[entry.setId.guid] = {
               mapName,
               location: entry.location,
+              name,
             };
           }
         }
@@ -125,22 +341,32 @@ async function processLootFiles(directoryData) {
         rewardTables = [data.rewardTableId.guid];
       }
       for (const rt of rewardTables) {
+        const tableInfo = getRewardTableInfo(directoryData, rt);
         const items = rewardMap[rt] || [];
         for (const item of items) {
+          const chanceInfo = computeItemChance(directoryData, rt, item);
+          const itemName = getItemName(directoryData, item);
           const id = `${item}_${questName}_${step}`;
           lootInfo.push({
             id,
             itemId: item,
+            itemName,
             questName,
             step,
             npcName: null,
-            levelMin: null,
-            levelMax: null,
+            levelMin: tableInfo.levelMin,
+            levelMax: tableInfo.levelMax,
             difficulty: null,
-            zone: null,
+            zone: tableInfo.biome,
             spawnRate: null,
-            dropChance: null,
-            coordinates: null,
+            dropChance: chanceInfo.chance,
+            dropChancePerRoll: chanceInfo.perRollChance,
+            rolls: chanceInfo.rolls,
+            poolSize: chanceInfo.poolSize,
+            zoneCoordinates: null,
+            worldCoordinates: null,
+            rewardTableId: rt,
+            worldSpawnLocation: null,
           });
         }
       }
@@ -163,36 +389,49 @@ async function processLootFiles(directoryData) {
           spawnInfos.push({
             levelMin: inst.levelMin,
             levelMax: inst.levelMax,
-            weight: def.weight,
+            spawnWeight: def.weight,
             spawnRate: inst.respawnTime,
             zone: w ? w.mapName : null,
-            coordinates: s ? s.location : null,
+            worldSpawnLocation: w ? w.name : null,
+            zoneCoordinates: s ? s.location : null,
+            worldCoordinates: w ? w.location : null,
           });
         }
       }
     }
 
     for (const rt of lootTables) {
+      const tableInfo = getRewardTableInfo(directoryData, rt);
       const items = rewardMap[rt] || [];
       for (const item of items) {
+        const chanceInfo = computeItemChance(directoryData, rt, item);
+        const itemName = getItemName(directoryData, item);
         for (const info of spawnInfos) {
-          const coord = info.coordinates || { x: 0, y: 0, z: 0 };
+          const coord = info.zoneCoordinates || { x: 0, y: 0, z: 0 };
           const id = `${item}_${asset.name}_${coord.x}_${coord.y}_${coord.z}`;
           lootInfo.push({
             id,
             itemId: item,
+            itemName,
             questName: null,
             step: null,
             npcName: asset.name,
-            levelMin: info.levelMin,
-            levelMax: info.levelMax,
-            difficulty: asset.gameplayTags && asset.gameplayTags.gameplayTags
-              ? asset.gameplayTags.gameplayTags.map((t) => t.tagName).join(" ")
-              : null,
-            zone: info.zone,
+            levelMin: tableInfo.levelMin ?? info.levelMin,
+            levelMax: tableInfo.levelMax ?? info.levelMax,
+            difficulty:
+              asset.gameplayTags && asset.gameplayTags.gameplayTags
+                ? asset.gameplayTags.gameplayTags.map((t) => t.tagName).join(" ")
+                : null,
+            zone: info.zone || tableInfo.biome,
             spawnRate: info.spawnRate,
-            dropChance: info.weight,
-            coordinates: info.coordinates,
+            dropChance: chanceInfo.chance,
+            dropChancePerRoll: chanceInfo.perRollChance,
+            rolls: chanceInfo.rolls,
+            poolSize: chanceInfo.poolSize,
+            zoneCoordinates: info.zoneCoordinates,
+            worldCoordinates: info.worldCoordinates,
+            rewardTableId: rt,
+            worldSpawnLocation: info.worldSpawnLocation,
           });
         }
       }


### PR DESCRIPTION
## Summary
- compute nested reward-table pool sizes to account for all candidate items when deriving drop chances
- attach world-spawn coordinates and names to NPC loot entries
- capture zone-relative and world coordinates separately for each spawn
- skip invalid reward table IDs (e.g., 0) to avoid missing-file errors during processing

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689abca0e13883229a8bc18ca98fb8a4