### PR TITLE
Restore effect wrapping and refine skill tokens

### DIFF
--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -276,6 +276,14 @@ async function processStatusEffects(directoryData, statIdToName) {
       );
     }
 
+    if (name === 'Bleeding') {
+      const tick = data.tickHitsIds?.[0];
+      const dmg = tick ? parseDamage(tick.guid, directoryData) : null;
+      if (dmg && dmg.percent) {
+        description = `Deals ${dmg.percent}% ${dmg.element} Damage over time`;
+      }
+    }
+
     let effectDuration = null;
     if (data.effectDuration?.expression) {
       const durExpr = parseValueExpression(

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -112,7 +112,9 @@ function escapeRegExp(str) {
 }
 
 function wrapStatusEffects(text, dataDir) {
-  const names = getStatusEffectNames(dataDir).sort((a, b) => b.length - a.length);
+  const names = getStatusEffectNames(dataDir)
+    .filter((n) => n.toLowerCase() !== 'combat momentum')
+    .sort((a, b) => b.length - a.length);
   const isWrapped = (str, start, end) => {
     const open = str.lastIndexOf('[', start);
     const close = str.indexOf(']', end);
@@ -870,9 +872,11 @@ function formatDescription(desc, ability, dataDir) {
     return eff ? `[${eff}]` : '';
   });
 
+  text = text.replace(/\{!skill:[^}]+\}/g, '');
   text = text.replace(/\{skill:([^:}]+):([^:}]+):([^}]+)\}/g, (m, cls, sk, desc) => {
-    const name = resolveSkillName(sk, dataDir);
     const clean = desc.replace(/<[^>]+>/g, '').trim();
+    if (/^\d+$/.test(clean)) return clean;
+    const name = resolveSkillName(sk, dataDir);
     return `${name}: ${clean}`;
   });
 
@@ -904,7 +908,7 @@ function formatDescription(desc, ability, dataDir) {
   text = text.replace(/\$flavor:([^$]+)\$/gi, (_, w) => `<i>${w.replace(/^"|"$/g, '')}</i>`);
   text = text.replace(/\\'/g, "'");
   text = text.replace(/Healing Damage/gi, 'Healing');
-  // Status effect names are now provided explicitly; avoid auto-wrapping
+  text = wrapStatusEffects(text, dataDir);
   text = text.replace(/\s+/g, ' ').trim();
   text = text.replace(/(<br>)+$/g, '').trim();
   if (text && !/[.!?]$/.test(text)) text += '.';


### PR DESCRIPTION
## Summary
- wrap ability text in matching status effect names, ignoring Combat Momentum
- strip optional skill placeholders and only show numeric ricochet bounces
- detail Bleeding as dealing 15% Physical Damage over time

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ad301e2908322894685a6f34b7e71