### PR TITLE
Refine Cheerful Melody and line break formatting

### DIFF
--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -284,6 +284,25 @@ async function processStatusEffects(directoryData, statIdToName) {
       }
     }
 
+    if (name === 'Cheerful Melody') {
+      const tickGuid = data.tickHitsIds?.[0]?.guid;
+      const tick = tickGuid ? parseDamage(tickGuid, directoryData) : null;
+      const elem = tick && tick.element ? `${tick.element} ` : '';
+      const healVal = tick && tick.percent ? `${tick.percent}% ${elem}Healing` : '';
+      const tickTime = data.tickTimer || 0;
+      const interval = tickTime ? `${tickTime} seconds` : '';
+      if (healVal && interval) {
+        description = `Grants 15% bonus healing. Also heals for ${healVal} every ${interval}.`;
+      } else {
+        description = `Grants 15% bonus healing.`;
+      }
+      description = description.trim();
+    }
+
+    if (name === 'Disarmed') {
+      description = description.replace(/\d+\s*\*[^=]+=\s*/g, '');
+    }
+
     let effectDuration = null;
     if (data.effectDuration?.expression) {
       const durExpr = parseValueExpression(

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -877,13 +877,17 @@ function formatDescription(desc, ability, dataDir) {
   });
 
   text = text.replace(/\{skill:([^:}]+):([^:}]+):(.*)\}/g, (m, cls, sk, desc) => {
-    const clean = desc.replace(/<[^>]+>/g, '').replace(/\}$/g, '').trim();
+    let clean = desc.replace(/<[^>]+>/g, '').replace(/\}$/g, '').trim();
     if (!clean) return '';
     if (clean.startsWith('{effect')) return '';
     if (/^\[[^\]]+\]$/.test(clean)) return '';
     if (/^\d+$/.test(clean)) return clean;
     const name = resolveSkillName(sk, dataDir);
-    return `${name}: ${clean}`;
+    const lowered = clean.toLowerCase();
+    if (lowered.startsWith(name.toLowerCase() + ':')) {
+      clean = clean.slice(name.length + 1).trim();
+    }
+    return ` [${name}]: ${clean}`;
   });
 
   const abilityName = (extractLastQuotedValue(ability.abilityName) || '').toLowerCase();
@@ -901,6 +905,8 @@ function formatDescription(desc, ability, dataDir) {
   text = text.replace(/(^|\W)rn/g, '$1<br>');
   text = text.replace(/\r\n|\n|\r/g, '<br>');
   text = text.replace(/(<br>)+/g, '<br>');
+  // Ensure each line break is preceded by a period
+  text = text.replace(/([^.!?\s])\s*<br>/g, '$1.<br>');
 
   text = text.replace(/(?:<br>)?\s*\$charges\$(?:\.)?/g, () => {
     const val = parseFloat(ability.cooldownCharges?.expression);


### PR DESCRIPTION
## Summary
- add baseline logic for Cheerful Melody with optional tick-based healing
- ensure each `<br>` line break is preceded by a period in ability text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689be20e44848322bd078512582cef2b