### PR TITLE
Handle multiplier stat mods as percentages

### DIFF
--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -160,12 +160,20 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
     if (t.includes('onlystat')) return statName || '';
     if (t.includes('by%') || t.startsWith('f%') || t.includes('%by')) {
       if (!isNaN(val)) {
-        return `${(val * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
+        let outVal = val;
+        if (/multiplier/i.test(statName) && outVal > 1) {
+          outVal = outVal - 1;
+        }
+        return `${(outVal * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();
     }
     if (!isNaN(val)) {
-      return `${val}${statName ? ' ' + statName : ''}`.trim();
+      let outVal = val;
+      if (/multiplier/i.test(statName) && outVal > 1) {
+        outVal = outVal - 1;
+      }
+      return `${outVal}${statName ? ' ' + statName : ''}`.trim();
     }
     return `${expr}${statName ? ' ' + statName : ''}`.trim();
   };

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -506,12 +506,20 @@ function resolveStatModPlaceholders(text, ability, dataDir) {
     if (t.includes('onlystat')) return statName || '';
     if (t.includes('by%') || t.startsWith('f%')) {
       if (!isNaN(val)) {
-        return `${(val * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
+        let outVal = val;
+        if (/multiplier/i.test(statName) && outVal > 1) {
+          outVal = outVal - 1;
+        }
+        return `${(outVal * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();
     }
     if (!isNaN(val)) {
-      return `${val}${statName ? ' ' + statName : ''}`.trim();
+      let outVal = val;
+      if (/multiplier/i.test(statName) && outVal > 1) {
+        outVal = outVal - 1;
+      }
+      return `${outVal}${statName ? ' ' + statName : ''}`.trim();
     }
     return `${expr}${statName ? ' ' + statName : ''}`.trim();
   };
@@ -920,7 +928,8 @@ function formatDescription(desc, ability, dataDir) {
   text = text.replace(/\$flavor:([^$]+)\$/gi, (_, w) => `<i>${w.replace(/^"|"$/g, '')}</i>`);
   text = text.replace(/\\'/g, "'");
   text = text.replace(/Healing Damage/gi, 'Healing');
-  // Status effect names are already resolved from ability data; avoid auto-wrapping
+  // Wrap any remaining status-effect names
+  text = wrapStatusEffects(text, dataDir);
   text = text.replace(/\s+/g, ' ').trim();
   text = text.replace(/(<br>)+$/g, '').trim();
   if (text && !/[.!?]$/.test(text)) text += '.';


### PR DESCRIPTION
## Summary
- adjust stat mod placeholder handling to subtract 1 from multiplier values before converting to percent
- auto-wrap status effect names in ability descriptions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f0696f48322b65ee5c49ad21ec5