### PR TITLE
fix rounding for stat modifiers and multipliers

### DIFF
--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -7,6 +7,7 @@ import {
   extractLastQuotedValue,
   parseValueExpression,
   formatTime,
+  formatNumber,
 } from '../utils.js';
 import { applySpecialCase } from '../special-cases.js';
 
@@ -156,7 +157,11 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
       statIdToName,
       dataDir
     );
-    const val = evaluateExpression(expr);
+    let val = evaluateExpression(expr);
+    if (isNaN(val)) {
+      const match = expr.match(/var\s+mod\s*=\s*([-+]?\d*\.?\d+)/i);
+      if (match) val = parseFloat(match[1]);
+    }
     const t = (type || '').toLowerCase();
     if (t.includes('onlystat')) return statName || '';
     if (t.includes('by%') || t.startsWith('f%') || t.includes('%by')) {
@@ -165,16 +170,19 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
         if (/multiplier/i.test(statName) && outVal > 1) {
           outVal = outVal - 1;
         }
-        return `${(outVal * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
+        return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();
     }
-    if (!isNaN(val)) {
+    if (/multiplier/i.test(statName) && !isNaN(val)) {
       let outVal = val;
-      if (/multiplier/i.test(statName) && outVal > 1) {
+      if (outVal > 1) {
         outVal = outVal - 1;
       }
-      return `${outVal}${statName ? ' ' + statName : ''}`.trim();
+      return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
+    }
+    if (!isNaN(val)) {
+      return `${formatNumber(val)}${statName ? ' ' + statName : ''}`.trim();
     }
     return `${expr}${statName ? ' ' + statName : ''}`.trim();
   };

--- a/src/special-cases.js
+++ b/src/special-cases.js
@@ -26,7 +26,7 @@ function convertMultiplier(text) {
     const num = parseFloat(n);
     if (Number.isNaN(num)) return `${n}% ${type} Multiplier`;
     const val = num > 1 ? (num - 1) * 100 : num;
-    const formatted = Number.isInteger(val) ? val : val.toFixed(2);
+    const formatted = Number.isInteger(val) ? val : parseFloat(val.toFixed(2));
     return `${formatted}% ${type} Multiplier`;
   });
 }

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -5,6 +5,7 @@ import {
   extractLastQuotedValue,
   parseValueExpression,
   extractCoefficient,
+  formatNumber,
 } from '../utils.js';
 import { statIdToName } from '../config.js';
 import { applySpecialCase } from '../special-cases.js';
@@ -509,25 +510,32 @@ function resolveStatModPlaceholders(text, ability, dataDir) {
       statIdToName,
       dataDir
     );
-    const val = evaluateExpression(expr);
+    let val = evaluateExpression(expr);
+    if (isNaN(val)) {
+      const match = expr.match(/var\s+mod\s*=\s*([-+]?\d*\.?\d+)/i);
+      if (match) val = parseFloat(match[1]);
+    }
     const t = (type || '').toLowerCase();
     if (t.includes('onlystat')) return statName || '';
-    if (t.includes('by%') || t.startsWith('f%')) {
+    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by')) {
       if (!isNaN(val)) {
         let outVal = val;
         if (/multiplier/i.test(statName) && outVal > 1) {
           outVal = outVal - 1;
         }
-        return `${(outVal * 100).toFixed(0)}%${statName ? ' ' + statName : ''}`.trim();
+        return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();
     }
-    if (!isNaN(val)) {
+    if (/multiplier/i.test(statName) && !isNaN(val)) {
       let outVal = val;
-      if (/multiplier/i.test(statName) && outVal > 1) {
+      if (outVal > 1) {
         outVal = outVal - 1;
       }
-      return `${outVal}${statName ? ' ' + statName : ''}`.trim();
+      return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
+    }
+    if (!isNaN(val)) {
+      return `${formatNumber(val)}${statName ? ' ' + statName : ''}`.trim();
     }
     return `${expr}${statName ? ' ' + statName : ''}`.trim();
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -464,6 +464,19 @@ function extractCoefficient(expression) {
 }
 
 /**
+ * Format numeric values to avoid floating point artifacts.
+ * Whole numbers have no decimal places, fractional values keep up to 2 decimals.
+ * @param {number} value - The numeric value to format
+ * @returns {string} Formatted number as a string
+ */
+function formatNumber(value) {
+  const num = Number(value);
+  if (Number.isNaN(num)) return '';
+  const rounded = Number(num.toFixed(2));
+  return rounded.toString();
+}
+
+/**
  * Formats a given number of seconds into a human-readable time string
  * @param {string} seconds - Number of seconds
  * @returns {string} A string representing the time in seconds, minutes, or hours
@@ -497,5 +510,6 @@ export {
   extractExpressionId,
   parseValueExpression,
   formatTime,
+  formatNumber,
   extractCoefficient,
 };


### PR DESCRIPTION
## Summary
- add utility to consistently round numeric values
- normalize stat mod placeholders to output whole or 2-decimal percentages and handle multipliers
- clean up multiplier formatting in special cases

## Testing
- `node --check src/utils.js && node --check src/processor/status-effects.js && node --check src/tools/parse-skill-table.js && node --check src/special-cases.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d76565a688322bba618c3ef276ce4