### PR TITLE
Fix effect and ability parsing

### DIFF
--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -8,6 +8,7 @@ import {
   parseValueExpression,
   formatTime,
   formatNumber,
+  extractCoefficient,
 } from '../utils.js';
 import { applySpecialCase } from '../special-cases.js';
 
@@ -75,7 +76,7 @@ function loadAbilityHit(hitKey, dataDir) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
-function parseDamage(hitKey, dataDir) {
+function parseDamage(hitKey, dataDir, statIdToName = {}) {
   const hit = loadAbilityHit(hitKey, dataDir);
   if (!hit) return null;
   const elementTag = hit.eventTags?.[0]?.tagName || '';
@@ -86,10 +87,31 @@ function parseDamage(hitKey, dataDir) {
     let mod = getJson(dataDir, '/Effects/StatMod', `StatMod_${statGuid}.json`);
     if (!mod || Object.keys(mod).length === 0)
       mod = getJson(dataDir, '/Effects/StatMod', `StatModRecord_${statGuid}.json`);
-    const expr = mod.valueInputTerms?.[0]?.value?.expression || mod.value?.expression;
+    let expr =
+      mod.valueInputTerms?.[0]?.value?.expression || mod.value?.expression || '';
     if (expr) {
-      const v = parseFloat(expr);
-      if (!Number.isNaN(v)) percent = v * 100;
+      expr = parseValueExpression(
+        expr,
+        mod.valueInputTerms,
+        statIdToName,
+        dataDir
+      );
+      let v = evaluateExpression(expr);
+      if (Number.isNaN(v)) {
+        const sel = expr.match(
+          /SelectFloat\([^,]+,\s*([-+]?\d*\.\d+|[-+]?\d+),\s*([-+]?\d*\.\d+|[-+]?\d+)\)/i
+        );
+        if (sel) v = Math.min(parseFloat(sel[1]), parseFloat(sel[2]));
+      }
+      if (Number.isNaN(v)) {
+        const coeff = parseFloat(extractCoefficient(expr));
+        if (!Number.isNaN(coeff)) v = coeff;
+        else {
+          const m = expr.match(/-?\d*\.\d+|-?\d+/);
+          if (m) v = parseFloat(m[0]);
+        }
+      }
+      if (!Number.isNaN(v)) percent = Math.max(0, v) * 100;
     }
   }
   return { element, percent };
@@ -150,7 +172,7 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
   const statMods = effectData.statModsIds || [];
   const replaceMod = (mod, type) => {
     if (!mod) return '';
-    const statName = statIdToName[mod.statRefId?.guid] || '';
+    let statName = statIdToName[mod.statRefId?.guid] || '';
     let expr = parseValueExpression(
       mod.value?.expression || '',
       mod.valueInputTerms,
@@ -158,14 +180,29 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
       dataDir
     );
     let val = evaluateExpression(expr);
-    if (isNaN(val)) {
+    if (Number.isNaN(val)) {
+      const sel = expr.match(
+        /SelectFloat\([^,]+,\s*([-+]?\d*\.\d+|[-+]?\d+),\s*([-+]?\d*\.\d+|[-+]?\d+)\)/i
+      );
+      if (sel) val = Math.min(parseFloat(sel[1]), parseFloat(sel[2]));
+    }
+    if (Number.isNaN(val)) {
       const match = expr.match(/var\s+mod\s*=\s*([-+]?\d*\.?\d+)/i);
       if (match) val = parseFloat(match[1]);
     }
-    const t = (type || '').toLowerCase();
+    if (Number.isNaN(val)) {
+      const coeff = parseFloat(extractCoefficient(expr));
+      if (!Number.isNaN(coeff)) val = coeff;
+    }
+    if (Number.isNaN(val)) {
+      const m = expr.match(/-?\d*\.\d+|-?\d+/);
+      if (m) val = parseFloat(m[0]);
+    }
+    let t = (type || '').toLowerCase();
+    if (t.includes('nostat')) statName = '';
     if (t.includes('onlystat')) return statName || '';
-    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by')) {
-      if (!isNaN(val)) {
+    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by') || t === '%') {
+      if (!Number.isNaN(val)) {
         let outVal = val;
         if (/multiplier/i.test(statName) && outVal > 1) {
           outVal = outVal - 1;
@@ -174,14 +211,12 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();
     }
-    if (/multiplier/i.test(statName) && !isNaN(val)) {
+    if (/multiplier/i.test(statName) && !Number.isNaN(val)) {
       let outVal = val;
-      if (outVal > 1) {
-        outVal = outVal - 1;
-      }
+      if (outVal > 1) outVal = outVal - 1;
       return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
     }
-    if (!isNaN(val)) {
+    if (!Number.isNaN(val)) {
       return `${formatNumber(val)}${statName ? ' ' + statName : ''}`.trim();
     }
     return `${expr}${statName ? ' ' + statName : ''}`.trim();
@@ -226,12 +261,12 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
   result = result.replace(/\$tick(\d+)\$/g, (m, idx) => {
     const hitRef = (effectData.tickHitsIds || [])[parseInt(idx, 10)];
     if (!hitRef) return m;
-    const dmg = parseDamage(hitRef.guid, dataDir);
+    const dmg = parseDamage(hitRef.guid, dataDir, statIdToName);
     return dmg && dmg.percent ? `${dmg.percent}% ${dmg.element} Damage` : m;
   });
 
   result = result.replace(/\$hit:([^\.]+)(?:\.[^$]+)?\$/g, (m, name) => {
-    const dmg = parseDamage(name, dataDir);
+    const dmg = parseDamage(name, dataDir, statIdToName);
     return dmg && dmg.percent ? `${dmg.percent}% ${dmg.element} Damage` : m;
   });
 
@@ -295,7 +330,7 @@ async function processStatusEffects(directoryData, statIdToName) {
 
     if (name === 'Bleeding') {
       const tick = data.tickHitsIds?.[0];
-      const dmg = tick ? parseDamage(tick.guid, directoryData) : null;
+      const dmg = tick ? parseDamage(tick.guid, directoryData, statIdToName) : null;
       if (dmg && dmg.percent) {
         description = `Deals ${dmg.percent}% ${dmg.element} Damage over time`;
       }
@@ -303,7 +338,7 @@ async function processStatusEffects(directoryData, statIdToName) {
 
     if (name === 'Cheerful Melody') {
       const tickGuid = data.tickHitsIds?.[0]?.guid;
-      const tick = tickGuid ? parseDamage(tickGuid, directoryData) : null;
+      const tick = tickGuid ? parseDamage(tickGuid, directoryData, statIdToName) : null;
       const elem = tick && tick.element ? `${tick.element} ` : '';
       const healVal = tick && tick.percent ? `${tick.percent}% ${elem}Healing` : '';
       const tickTime = data.tickTimer || 0;

--- a/src/special-cases.js
+++ b/src/special-cases.js
@@ -42,7 +42,10 @@ const handlers = {
   Glee: (name, desc) => ({ description: replaceRangeWithMin(desc) }),
   Pep: (name, desc) => ({ description: replaceRangeWithMin(desc) }),
   Resonance: (name, desc) => ({ description: convertMultiplier(desc) }),
-  Solace: (name, desc) => ({ description: replaceRangeWithMax(desc) }),
+  Solace: () => ({
+    description:
+      'Gain up to 75% of your Max Health. Healing Received increases healing received for 5 seconds based on how much health was lost from a bard\'s gabit.',
+  }),
   'Staggered': () => ({
     description:
       '-25% Disable Evasion for 6 seconds. Duration can be extended up to 15 seconds by subsequent applications.',
@@ -81,6 +84,12 @@ const handlers = {
   'Hymn of the Mind (AoE)': () => ({
     description:
       'Up to 4 allies in front of you gain mana equal to 4.8% Magical Power every second. Mana gained increases up to 200% based on the amount of mana the target is missing. This ability will favor low mana party members and yourself.',
+  }),
+  'Anthem of Alacrity': () => ({
+    description: 'Target ally gains [Anthem Of Alacrity].',
+  }),
+  'Anthem of Alacrity (AoE)': () => ({
+    description: 'You and the closest allies in front of you gain [Anthem Of Minor Alacrity].',
   }),
   'Chilling Lament': () => ({
     description:
@@ -125,6 +134,12 @@ const handlers = {
   Doublestrike: () => ({
     description:
       'Strike again with the last used melee ability from this list.\nStab - Lacerate - Thump',
+  }),
+  Firebolt: (name, desc) => ({
+    description: desc ? desc.replace(/\[Fireball\]/g, 'Fireball') : desc,
+  }),
+  'Flash Cure': (name, desc) => ({
+    description: desc ? desc.replace(/^<br>/, '') : desc,
   }),
   Throw: (name, desc) => ({
     description: desc

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -127,8 +127,11 @@ function escapeRegExp(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function wrapStatusEffects(text, dataDir) {
-  const names = getStatusEffectNames(dataDir).sort((a, b) => b.length - a.length);
+function wrapStatusEffects(text, dataDir, skip = []) {
+  const skipSet = new Set(skip.map((s) => s.toLowerCase()));
+  const names = getStatusEffectNames(dataDir)
+    .filter((n) => !skipSet.has(n.toLowerCase()))
+    .sort((a, b) => b.length - a.length);
   const isWrapped = (str, start, end) => {
     const open = str.lastIndexOf('[', start);
     const close = str.indexOf(']', end);
@@ -227,6 +230,12 @@ function parseDamage(hitKey, dataDir) {
         dataDir
       );
       let v = evaluateExpression(expr);
+      if (Number.isNaN(v)) {
+        const sel = expr.match(
+          /SelectFloat\([^,]+,\s*([-+]?\d*\.\d+|[-+]?\d+),\s*([-+]?\d*\.\d+|[-+]?\d+)\)/i
+        );
+        if (sel) v = Math.min(parseFloat(sel[1]), parseFloat(sel[2]));
+      }
       if (Number.isNaN(v)) {
         const coeff = parseFloat(extractCoefficient(expr));
         if (!Number.isNaN(coeff)) v = coeff;
@@ -503,7 +512,7 @@ function resolveStatModPlaceholders(text, ability, dataDir) {
 
   const replaceMod = (mod, type) => {
     if (!mod) return '';
-    const statName = statIdToName[mod.statRefId?.guid] || '';
+    let statName = statIdToName[mod.statRefId?.guid] || '';
     let expr = parseValueExpression(
       mod.value?.expression || '',
       mod.valueInputTerms,
@@ -511,30 +520,41 @@ function resolveStatModPlaceholders(text, ability, dataDir) {
       dataDir
     );
     let val = evaluateExpression(expr);
-    if (isNaN(val)) {
+    if (Number.isNaN(val)) {
+      const sel = expr.match(
+        /SelectFloat\([^,]+,\s*([-+]?\d*\.\d+|[-+]?\d+),\s*([-+]?\d*\.\d+|[-+]?\d+)\)/i
+      );
+      if (sel) val = Math.min(parseFloat(sel[1]), parseFloat(sel[2]));
+    }
+    if (Number.isNaN(val)) {
       const match = expr.match(/var\s+mod\s*=\s*([-+]?\d*\.?\d+)/i);
       if (match) val = parseFloat(match[1]);
     }
-    const t = (type || '').toLowerCase();
+    if (Number.isNaN(val)) {
+      const coeff = parseFloat(extractCoefficient(expr));
+      if (!Number.isNaN(coeff)) val = coeff;
+    }
+    if (Number.isNaN(val)) {
+      const m = expr.match(/-?\d*\.\d+|-?\d+/);
+      if (m) val = parseFloat(m[0]);
+    }
+    let t = (type || '').toLowerCase();
+    if (t.includes('nostat')) statName = '';
     if (t.includes('onlystat')) return statName || '';
-    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by')) {
-      if (!isNaN(val)) {
+    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by') || t === '%') {
+      if (!Number.isNaN(val)) {
         let outVal = val;
-        if (/multiplier/i.test(statName) && outVal > 1) {
-          outVal = outVal - 1;
-        }
+        if (/multiplier/i.test(statName) && outVal > 1) outVal = outVal - 1;
         return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();
     }
-    if (/multiplier/i.test(statName) && !isNaN(val)) {
+    if (/multiplier/i.test(statName) && !Number.isNaN(val)) {
       let outVal = val;
-      if (outVal > 1) {
-        outVal = outVal - 1;
-      }
+      if (outVal > 1) outVal = outVal - 1;
       return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
     }
-    if (!isNaN(val)) {
+    if (!Number.isNaN(val)) {
       return `${formatNumber(val)}${statName ? ' ' + statName : ''}`.trim();
     }
     return `${expr}${statName ? ' ' + statName : ''}`.trim();
@@ -945,8 +965,11 @@ function formatDescription(desc, ability, dataDir) {
   text = text.replace(/\$flavor:([^$]+)\$/gi, (_, w) => `<i>${w.replace(/^"|"$/g, '')}</i>`);
   text = text.replace(/\\'/g, "'");
   text = text.replace(/Healing Damage/gi, 'Healing');
-  // Wrap any remaining status-effect names
-  text = wrapStatusEffects(text, dataDir);
+  let skipWrap = [];
+  if (abilityName === 'doublestrike') skipWrap = ['Lacerate'];
+  if (abilityName === 'firebolt') skipWrap.push('Fireball');
+  text = wrapStatusEffects(text, dataDir, skipWrap);
+  text = text.replace(/^<br>/, '');
   // Collapse any accidental double brackets
   text = text.replace(/\[\[([^\[\]]+)\]\]/g, '[$1]');
   text = text.replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## Summary
- improve statmod and damage parsing to handle percentages and complex expressions
- add special cases for Solace, Anthem of Alacrity variants, Firebolt, and Flash Cure
- skip keyword wrapping for specific abilities and clean up formatting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e418e35408322ab833ade1b829397