### PR TITLE
Correct effect percentages and ability calculations

### DIFF
--- a/src/processor/status-effects.js
+++ b/src/processor/status-effects.js
@@ -107,8 +107,13 @@ function parseDamage(hitKey, dataDir, statIdToName = {}) {
         const coeff = parseFloat(extractCoefficient(expr));
         if (!Number.isNaN(coeff)) v = coeff;
         else {
-          const m = expr.match(/-?\d*\.\d+|-?\d+/);
-          if (m) v = parseFloat(m[0]);
+          const matches = expr.match(/-?\d*\.\d+|-?\d+/g);
+          if (matches) {
+            const nums = matches
+              .map(Number)
+              .filter((n) => !Number.isNaN(n) && Math.abs(n) < 1000);
+            if (nums.length) v = nums[0];
+          }
         }
       }
       if (!Number.isNaN(v)) percent = Math.max(0, v) * 100;
@@ -195,18 +200,24 @@ function resolvePlaceholders(text, effectData, dataDir, statIdToName) {
       if (!Number.isNaN(coeff)) val = coeff;
     }
     if (Number.isNaN(val)) {
-      const m = expr.match(/-?\d*\.\d+|-?\d+/);
-      if (m) val = parseFloat(m[0]);
+      const matches = expr.match(/-?\d*\.\d+|-?\d+/g);
+      if (matches) {
+        const nums = matches
+          .map(Number)
+          .filter((n) => !Number.isNaN(n) && Math.abs(n) < 1000);
+        if (nums.length) val = nums[0];
+      }
     }
     let t = (type || '').toLowerCase();
+    const subtractOne = t.includes('%-1') || t.includes('-1%');
+    if (subtractOne) t = t.replace('%-1', '%').replace('-1%', '%');
     if (t.includes('nostat')) statName = '';
     if (t.includes('onlystat')) return statName || '';
-    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by') || t === '%') {
+    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by') || t === '%' || t.includes('%')) {
       if (!Number.isNaN(val)) {
         let outVal = val;
-        if (/multiplier/i.test(statName) && outVal > 1) {
-          outVal = outVal - 1;
-        }
+        if (subtractOne) outVal = outVal - 1;
+        else if (/multiplier/i.test(statName) && outVal > 1) outVal = outVal - 1;
         return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();

--- a/src/special-cases.js
+++ b/src/special-cases.js
@@ -143,7 +143,7 @@ const handlers = {
   }),
   Throw: (name, desc) => ({
     description: desc
-      ? desc.replace('bounces up to {!skill:Rogue:Rogue_Passive_Throw_Ricochet:2}', 'bounces up to 5')
+      ? desc.replace(/bounces up to \d+/, 'bounces up to 5')
       : 'Throw bounces up to 5 times to other nearby enemies dealing lesser damage with each bounce.',
   }),
   'Soothing Shadows': () => ({

--- a/src/tools/parse-skill-table.js
+++ b/src/tools/parse-skill-table.js
@@ -240,8 +240,13 @@ function parseDamage(hitKey, dataDir) {
         const coeff = parseFloat(extractCoefficient(expr));
         if (!Number.isNaN(coeff)) v = coeff;
         else {
-          const m = expr.match(/-?\d*\.\d+|-?\d+/);
-          if (m) v = parseFloat(m[0]);
+          const matches = expr.match(/-?\d*\.\d+|-?\d+/g);
+          if (matches) {
+            const nums = matches
+              .map(Number)
+              .filter((n) => !Number.isNaN(n) && Math.abs(n) < 1000);
+            if (nums.length) v = nums[0];
+          }
         }
       }
       if (!Number.isNaN(v)) percent = Math.max(0, v) * 100;
@@ -535,16 +540,24 @@ function resolveStatModPlaceholders(text, ability, dataDir) {
       if (!Number.isNaN(coeff)) val = coeff;
     }
     if (Number.isNaN(val)) {
-      const m = expr.match(/-?\d*\.\d+|-?\d+/);
-      if (m) val = parseFloat(m[0]);
+      const matches = expr.match(/-?\d*\.\d+|-?\d+/g);
+      if (matches) {
+        const nums = matches
+          .map(Number)
+          .filter((n) => !Number.isNaN(n) && Math.abs(n) < 1000);
+        if (nums.length) val = nums[0];
+      }
     }
     let t = (type || '').toLowerCase();
+    const subtractOne = t.includes('%-1') || t.includes('-1%');
+    if (subtractOne) t = t.replace('%-1', '%').replace('-1%', '%');
     if (t.includes('nostat')) statName = '';
     if (t.includes('onlystat')) return statName || '';
-    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by') || t === '%') {
+    if (t.includes('by%') || t.startsWith('f%') || t.includes('%by') || t === '%' || t.includes('%')) {
       if (!Number.isNaN(val)) {
         let outVal = val;
-        if (/multiplier/i.test(statName) && outVal > 1) outVal = outVal - 1;
+        if (subtractOne) outVal = outVal - 1;
+        else if (/multiplier/i.test(statName) && outVal > 1) outVal = outVal - 1;
         return `${formatNumber(outVal * 100)}%${statName ? ' ' + statName : ''}`.trim();
       }
       return `${expr}${statName ? ' ' + statName : ''}`.trim();


### PR DESCRIPTION
## Summary
- fix percentage formatting for effects like Tragedy, Comedy, and Glee
- recalculate damage parsing to prevent inflated values
- ensure Throw ability shows only 5 bounces

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e83659ce4832293c782ea49d6ff30